### PR TITLE
Add Paginator component

### DIFF
--- a/src/components/Paginator/Paginator.css
+++ b/src/components/Paginator/Paginator.css
@@ -1,0 +1,83 @@
+:root {
+  --paginator--font-size: 0.875rem;
+  --paginator--min-height: calc(var(--paginator--font-size) * 4);
+  --paginator--border-radius: 9999px;
+
+  --paginator--button-size: var(--paginator--min-height);
+  --paginator--button-icon-size: calc(var(--paginator--button-size) / 2.5);
+}
+
+.paginator-wrapper {
+  /* Cover the entire parent element and don't scroll with it. */
+  position: fixed;
+  inset: var(--fixed-spacing--3x);
+
+  /* But pass all pointer events through to the table behind. */
+  pointer-events: none;
+
+  /* Position the paginator itself (child element) at the bottom center of the body. */
+  display: grid;
+  place-items: end center;
+}
+
+.paginator {
+  /* Re-capture pointer events (clicks, etc.) that were canceled on the wrapper. */
+  pointer-events: auto;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--fixed-spacing--2x);
+
+  overflow: hidden;
+  min-height: var(--paginator--min-height);
+  background-color: white;
+  border-radius: var(--paginator--border-radius);
+  box-shadow: 0 0 3px var(--color--gray--medium);
+
+  font-size: var(--paginator--font-size);
+  line-height: 1;
+}
+
+.paginator-button {
+  all: unset;
+
+  height: var(--paginator--button-size);
+  width: var(--paginator--button-size);
+  border-radius: var(--paginator--border-radius);
+  background-color: var(--color--gray--light);
+  color: var(--color--gray--darker);
+  cursor: pointer;
+
+  display: grid;
+  place-content: center;
+}
+
+.paginator-button .icon {
+  height: var(--paginator--button-icon-size);
+  width: var(--paginator--button-icon-size);
+}
+
+.paginator-button:disabled {
+  color: var(--color--gray--medium);
+  cursor: not-allowed;
+}
+
+.paginator-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--accessible-spacing--halfx);
+  text-align: center;
+
+  text-transform: uppercase;
+}
+
+.paginator-status__value {
+  font-weight: var(--font-weight--medium);
+}
+
+.paginator__page-selector {
+  font-weight: var(--font-weight--medium);
+}

--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { PaginatorButton } from './PaginatorButton';
+import './Paginator.css';
+
+interface MakePagesProps {
+  totalItems: number,
+  itemsPerPage: number,
+}
+
+interface PaginatorPage {
+  pageNumber: number,
+  firstItem: number,
+  lastItem: number,
+}
+
+/**
+   * Given a total number of items and the number of items desired per page,
+   * generates an array of page definitions.
+   *
+   * @param  {Object} Total items and items per page, from which we can calculate the rest.
+   * @return {PaginatorPage[]} An array of `PaginatorPage`s.
+   */
+const makePages = ({
+  totalItems = 0,
+  itemsPerPage = 100, // This is a generic fallback, not our real configuration.
+}: MakePagesProps) => {
+  const pages: PaginatorPage[] = [];
+
+  if (itemsPerPage !== 0) {
+    const pageNumbers = Math.ceil(totalItems / itemsPerPage);
+    for (let i = 1; i <= pageNumbers; i += 1) {
+      const previousPageEnd = (i - 1) * itemsPerPage;
+      pages.push({
+        pageNumber: i,
+        firstItem: previousPageEnd + 1,
+        lastItem: Math.min(i * itemsPerPage, totalItems),
+      });
+    }
+  }
+
+  return pages;
+};
+
+/**
+   * Given a single PaginatorPage, returns a range string
+   * in the form of `1–100` or `201–245`.
+   *
+   * If the "range" is just a single value, it returns that value.
+   *
+   * @param  {PaginatorPage}
+   * @return {String} A range in `n-n` form, e.g. `1–100`, or just a single `n`, e.g. `1`.
+   */
+function formatPageBoundaries(page: PaginatorPage) {
+  if (page.firstItem === page.lastItem) {
+    return page.firstItem.toLocaleString();
+  }
+
+  return `${page.firstItem.toLocaleString()}–${page.lastItem.toLocaleString()}`;
+}
+
+interface PaginatorProps {
+  itemsPerPage: number,
+  totalItems: number,
+  /**
+   * Externally-managed current page.
+   * Note that there is no protection against this being set
+   * to a value larger than `totalItems / itemsPerPage`.
+   */
+  currentPage: number,
+  /**
+   * Function that will update the `currentPage`.
+   * Assumed to be a state hook, but not required.
+   * All that's required is that the external component
+   * change the `currentPage` property above.
+   */
+  setCurrentPage: (page: number) => void,
+}
+
+/**
+ * A component for navigating between pages of a set of items.
+ * Calculates the number of pages and the range start/end values
+ * based on the `totalItems` and `itemsPerPage` props.
+ * Note that "current page" state should be managed externally,
+ * so changing the `currentPage` prop internally has no effect.
+ */
+export const Paginator = ({
+  itemsPerPage,
+  totalItems,
+  currentPage,
+  setCurrentPage,
+}: PaginatorProps) => {
+  const pages = makePages({ itemsPerPage, totalItems });
+
+  const totalPages = pages.length;
+
+  const goToPreviousPage = () => {
+    setCurrentPage(Math.min(totalPages, Math.max(1, currentPage - 1)));
+  };
+
+  const goToNextPage = () => {
+    setCurrentPage(Math.max(1, Math.min(totalPages, currentPage + 1)));
+  };
+
+  const handleSelectorChange = (event: React.FormEvent) => {
+    const selector = event.currentTarget as HTMLSelectElement;
+    setCurrentPage(Number(selector.value));
+  };
+
+  return (typeof pages[0] === 'undefined')
+    // Don't render the paginator if we can't generate any page definitions.
+    ? null
+    : (
+      <div className="paginator">
+        <PaginatorButton
+          direction="previous"
+          onClick={goToPreviousPage}
+          disabled={currentPage <= 1}
+        />
+        <div className="paginator-content">
+          <div className="paginator-status">
+            {'Showing '}
+            {totalPages > 1 ? (
+              <select
+                onChange={handleSelectorChange}
+                value={currentPage}
+                className="paginator__page-selector"
+              >
+                {pages.map((page) => (
+                  <option
+                    key={page.pageNumber}
+                    value={page.pageNumber}
+                  >
+                    {formatPageBoundaries(page)}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span className="paginator-status__value">
+                {formatPageBoundaries(pages[0])}
+              </span>
+            )}
+            {' of '}
+            <span className="paginator-status__value">
+              {totalItems.toLocaleString()}
+            </span>
+          </div>
+        </div>
+        <PaginatorButton
+          direction="next"
+          onClick={goToNextPage}
+          disabled={currentPage >= totalPages}
+        />
+      </div>
+    );
+};

--- a/src/components/Paginator/PaginatorButton.tsx
+++ b/src/components/Paginator/PaginatorButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/solid';
+
+interface PaginatorButtonProps {
+  direction: 'previous' | 'next',
+  onClick: () => void;
+  disabled?: boolean,
+}
+
+export const PaginatorButton = ({
+  direction,
+  onClick,
+  disabled = false,
+}: PaginatorButtonProps) => (
+  <button
+    className="paginator-button"
+    disabled={disabled}
+    onClick={onClick}
+    type="button"
+  >
+    {direction === 'previous'
+      ? <ArrowLeftIcon className="icon" />
+      : <ArrowRightIcon className="icon" />}
+  </button>
+);

--- a/src/components/Paginator/PaginatorWrapper.tsx
+++ b/src/components/Paginator/PaginatorWrapper.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface PaginatorWrapperProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const PaginatorWrapper = ({
+  children,
+  className = '',
+}: PaginatorWrapperProps) => (
+  <div className={`paginator-wrapper ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/src/components/Paginator/index.ts
+++ b/src/components/Paginator/index.ts
@@ -1,0 +1,9 @@
+import { Paginator } from './Paginator';
+import { PaginatorButton } from './PaginatorButton';
+import { PaginatorWrapper } from './PaginatorWrapper';
+
+export {
+  Paginator,
+  PaginatorButton,
+  PaginatorWrapper,
+};

--- a/src/stories/Paginator.stories.tsx
+++ b/src/stories/Paginator.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Paginator } from '../components/Paginator/Paginator';
+
+const meta = {
+  component: Paginator,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Paginator>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    itemsPerPage: 100,
+    totalItems: 950,
+    currentPage: 1,
+    setCurrentPage: () => (false),
+  },
+};


### PR DESCRIPTION
This PR adds the `Paginator` component and its story, as well as the `PaginatorWrapper` that we use when actually placing the paginator on a real body:

<img width="433" alt="Paginator" src="https://user-images.githubusercontent.com/4731/236273226-90d7aeb4-6549-46ec-979d-a6e88c36d976.png">

There are also two utility methods that could easily be moved to a utility file, but we don’t yet have a pattern for that.

**Testing:**
1. `npm run storybook` and look at the `Paginator` story
2. `npm start`
3. To see it in context (but without true functionality), modify `ProposalListTablePanel.tsx` so the `<PanelBody>` looks like this:
    ```jsx
    <PanelBody>
      <PaginatorWrapper>
        <Paginator
          itemsPerPage={100}
          totalItems={950}
          currentPage={1}
          setCurrentPage={(page) => { console.log(page); }}
        />
      </PaginatorWrapper>
      <ProposalListTable
        fieldNames={fieldNames}
        proposals={proposals}
        columns={DEFAULT_COLUMNS}
        wrap={wrap}
      />
    </PanelBody>
    ```

Contributes to #15

_Extracted from #46, which can now be closed._