### PR TITLE
Rename repo from data-viewer to front-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@
 REACT_APP_OIDC_AUTHORITY=https://auth.example.com/realms/example
 
 # The client ID is assigned by the IdP
-REACT_APP_OIDC_CLIENT_ID=example-data-viewer
+REACT_APP_OIDC_CLIENT_ID=example-front-end
 
 # The API URL is the location of a running PhilanthropyDataCommons/service instance
 # https://github.com/PhilanthropyDataCommons/service

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# data-viewer
+# front-end
 A UI for interacting with the data stored in the PDC service
 
 ## Dependencies
@@ -8,14 +8,14 @@ Open ID Connect ("OIDC")
 identity provider ("IdP")
 for authentication.
 It should be agnostic about what kind of IdP is used.
-To use the data-viewer application,
+To use the front-end application,
 you will need to be able to log in.
 
 ## Configuration
 
 ### Identity Provider
 
-The IdP needs a client for the data-viewer.
+The IdP needs a client for the front-end.
 The IdP should be configured for the client to use the
 [Authorization Code flow](https://oauth.net/2/grant-types/authorization-code/).
 This client is a public client,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "data-viewer",
+  "name": "front-end",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "data-viewer",
+      "name": "front-end",
       "version": "0.1.0",
       "dependencies": {
         "@axa-fr/react-oidc": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "data-viewer",
+  "name": "front-end",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/ProposalListGrid.tsx
+++ b/src/components/ProposalListGrid.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
 import { ProposalListGridItem } from './ProposalListGridItem';
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 
 interface ProposalListGridProps {
-  proposals: DataViewerProposal[];
+  proposals: FrontEndProposal[];
   activeProposalId?: string | undefined;
 }
 

--- a/src/components/ProposalListGridItem.tsx
+++ b/src/components/ProposalListGridItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { getPreferredApplicantNameValues } from '../utils/proposals';
 import './ProposalListGridItem.css';
 
 interface ProposalListGridItemProps {
-  proposal: DataViewerProposal;
+  proposal: FrontEndProposal;
   active?: boolean;
 }
 

--- a/src/components/ProposalListGridPanel.tsx
+++ b/src/components/ProposalListGridPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import {
   Panel,
   PanelBody,
@@ -7,7 +7,7 @@ import {
 import { ProposalListGrid } from './ProposalListGrid';
 
 interface ProposalListGridPanelProps {
-  proposals: DataViewerProposal[];
+  proposals: FrontEndProposal[];
   activeProposalId?: string | undefined;
 }
 

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { getPreferredApplicantNameValues } from '../utils/proposals';
 import {
   Table,
@@ -13,7 +13,7 @@ import {
 
 interface ProposalListTableRowProps {
   columns: string[];
-  proposal: DataViewerProposal;
+  proposal: FrontEndProposal;
 }
 
 const ProposalListTableRow = ({
@@ -48,7 +48,7 @@ const ProposalListTableRow = ({
 interface ProposalListTableProps {
   columns: string[];
   fieldNames: Record<string, string>;
-  proposals: DataViewerProposal[];
+  proposals: FrontEndProposal[];
   wrap?: boolean;
 }
 

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import {
   Panel,
   PanelHeader,
@@ -13,7 +13,7 @@ import { Search } from './Search';
 
 interface ProposalListTablePanelProps {
   fieldNames: Record<string, string>;
-  proposals: DataViewerProposal[];
+  proposals: FrontEndProposal[];
   onSearch: (query: string) => void;
   searchQuery?: string;
   loading?: boolean;

--- a/src/interfaces/FrontEndProposal.ts
+++ b/src/interfaces/FrontEndProposal.ts
@@ -1,4 +1,4 @@
-export interface DataViewerProposal {
+export interface FrontEndProposal {
   id: string;
   values: Record<string, string[]>;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,7 +5,7 @@ const level = process.env.REACT_APP_LOG_LEVEL
   ?? (process.env.NODE_ENV === 'production' ? 'error' : 'info');
 
 const logger = pino({
-  name: 'data-viewer',
+  name: 'front-end',
   level,
   browser: {
     asObject: true,

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -73,7 +73,7 @@ const Landing = () => {
             <dt>Recent improvements</dt>
             <dd>
               <OffsiteLink
-                to="https://github.com/PhilanthropyDataCommons/data-viewer/blob/main/RECENT_CHANGES.md"
+                to="https://github.com/PhilanthropyDataCommons/front-end/blob/main/RECENT_CHANGES.md"
               >
                 Read a summary of recent changes here.
               </OffsiteLink>

--- a/src/utils/proposals.test.ts
+++ b/src/utils/proposals.test.ts
@@ -1,4 +1,4 @@
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import {
   getPreferredApplicantNameValues,
   PROPOSAL_APPLICANT_NAME_CASCADE,
@@ -14,7 +14,7 @@ const proposal = {
     proposal_primary_contact_name: ['Proposal Contact Name'],
     proposal_submitter_name: ['Proposal Submitter Name'],
   },
-} as DataViewerProposal;
+} as FrontEndProposal;
 
 test('can select most preferred applicant name', () => {
   const mostPreferredNameKey = PROPOSAL_APPLICANT_NAME_CASCADE[0] ?? '';
@@ -30,7 +30,7 @@ test('can cascade through preferred applicant names', () => {
     values: {
       [leastPreferredNameKey]: leastPreferredNameValues,
     },
-  } as DataViewerProposal;
+  } as FrontEndProposal;
 
   expect(getPreferredApplicantNameValues(leastPreferredProposal)).toEqual(leastPreferredNameValues);
 });
@@ -39,7 +39,7 @@ test('can fall back to fallback applicant name', () => {
   const blankProposal = {
     id: '123',
     values: {},
-  } as DataViewerProposal;
+  } as FrontEndProposal;
 
   expect(getPreferredApplicantNameValues(blankProposal))
     .toEqual([PROPOSAL_APPLICANT_NAME_FALLBACK]);

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -1,4 +1,4 @@
-import { DataViewerProposal } from '../interfaces/DataViewerProposal';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 
 const PROPOSAL_APPLICANT_NAME_CASCADE = [
   'organization_name',
@@ -17,10 +17,10 @@ const PROPOSAL_APPLICANT_NAME_FALLBACK = 'Unknown Applicant';
    * and returns the first matching value.
    * If none is found, falls back to the fallback value.
    *
-   * @param  {DataViewerProposal} proposal
+   * @param  {FrontEndProposal} proposal
    * @return {(Array)} The applicant name value array.
    */
-const getPreferredApplicantNameValues = (proposal: DataViewerProposal) => {
+const getPreferredApplicantNameValues = (proposal: FrontEndProposal) => {
   const bestNameKey = PROPOSAL_APPLICANT_NAME_CASCADE.find((key) => proposal.values[key]);
 
   if (bestNameKey) {


### PR DESCRIPTION
Update all the places that the repository name occurs. This does not update any in-app user-facing strings, per @kfogel's [suggestion](https://github.com/PhilanthropyDataCommons/data-viewer/issues/315#issuecomment-1716320859).

Issue #315 Choose new name for Data Viewer