### PR TITLE
Replace user-facing references to "data viewer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# front-end
-A UI for interacting with the data stored in the PDC service
+# Philanthropy Data Commons Front End
+A UI for interacting with the data stored in the PDC service.
 
 ## Dependencies
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,4 +1,4 @@
-# Recent Changes to the PDC Data Viewer
+# Recent Changes to the PDC Pilot
 
 ## June 2023
 

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="%PUBLIC_URL%/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Philanthropy Data Commons Data Viewer</title>
+    <title>Philanthropy Data Commons Pilot</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "PDC Pilot",
-  "name": "Philanthropy Data Commons Pilot Data Viewer",
+  "name": "Philanthropy Data Commons Pilot",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -15,7 +15,7 @@ const AppNavbar = () => (
       </li>
       <li>
         <a
-          href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons%20pilot%20data%20viewer"
+          href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons%20Pilot"
           className="App-navbar__item"
         >
           <EnvelopeIcon />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -18,9 +18,9 @@ const Landing = () => {
   return (
     <Panel className="landing-panel">
       <PanelBody>
-        <h3 style={{ fontWeight: '600' }}>Welcome to the Philanthropy Data Commons pilot.</h3>
+        <h3 style={{ fontWeight: '600' }}>Welcome to the Philanthropy Data Commons Pilot.</h3>
         <p>
-          This data viewer displays the data in the Philanthropy Data Commons pilot.
+          This pilot site displays the data in the Philanthropy Data Commons.
           {' '}
           <OffsiteLink to="https://philanthropydatacommons.org">
             Read more about the project here.


### PR DESCRIPTION
This PR replaces all user-facing references to the "data viewer" with context-appropriate variations of "the Philanthropy Data Commons". While in the pilot phase, we continue to append the word "pilot", but we can remove that word whenever we want without further rewriting or copy edits.

It also replaces the project README's auto-generated title with a more descriptive one.

Closes #315