### PR TITLE
Remove “pilot” terminology

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,4 +1,4 @@
-# Recent Changes to the PDC Pilot
+# Recent Changes to the PDC
 
 ## June 2023
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Displays the data in the Philanthropy Data Commons pilot. Read more at philanthropydatacommons.org."
+      content="Displays the data in the Philanthropy Data Commons. Read more at philanthropydatacommons.org."
     />
     <meta name="theme-color" content="#343434" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="icon" href="%PUBLIC_URL%/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Philanthropy Data Commons Pilot</title>
+    <title>Philanthropy Data Commons</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "PDC Pilot",
-  "name": "Philanthropy Data Commons Pilot",
+  "short_name": "PDC",
+  "name": "Philanthropy Data Commons",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -15,7 +15,7 @@ const AppNavbar = () => (
       </li>
       <li>
         <a
-          href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons%20Pilot"
+          href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons"
           className="App-navbar__item"
         >
           <EnvelopeIcon />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -18,9 +18,9 @@ const Landing = () => {
   return (
     <Panel className="landing-panel">
       <PanelBody>
-        <h3 style={{ fontWeight: '600' }}>Welcome to the Philanthropy Data Commons Pilot.</h3>
+        <h3 style={{ fontWeight: '600' }}>Welcome to the Philanthropy Data Commons.</h3>
         <p>
-          This pilot site displays the data in the Philanthropy Data Commons.
+          This site displays the data in the Philanthropy Data Commons.
           {' '}
           <OffsiteLink to="https://philanthropydatacommons.org">
             Read more about the project here.
@@ -53,7 +53,7 @@ const Landing = () => {
                 {' '}
                 <EmailLink
                   to="jimmcgowan@opentechstrategies.com"
-                  subject="PDC Pilot account"
+                  subject="PDC account"
                 />
               </dd>
             </Dli>
@@ -65,7 +65,7 @@ const Landing = () => {
               {' '}
               <EmailLink
                 to="info@philanthropydatacommons.org"
-                subject="PDC Pilot"
+                subject="PDC"
               />
             </dd>
           </Dli>


### PR DESCRIPTION
This PR removes the term "pilot" from around the site.

It doesn't close the attached issue, because to complete the task we'll need to configure the site to be hosted at a different subdomain; however, that won't require any further code changes, so this can be merged independently of that transition.

**Testing:**
1. Open the deploy preview URL (see below)
2. Verify that the page title (window/tab) and the landing page copy don't say "pilot"
3. Click on some of the email links and verify the subject lines don't contain the word "pilot"

Affects #333 