### PR TITLE
Add Contributing and Code of Conduct files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+If you're interested in contributing to this project,
+please read the
+[general PDC code of conduct](https://github.com/PhilanthropyDataCommons/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,26 @@
 # Contributing
 
 If you're interested in contributing to this project,
-please read the
+please start with the
 [general PDC contribution guidelines](https://github.com/PhilanthropyDataCommons/.github/blob/main/CONTRIBUTING.md).
+
+## Guidelines specific to this project
+
+### Populating "Recent Changes"
+
+If your change affects the user experience,
+describe it in concise, non-technical language
+in the `RECENT_CHANGES.md` document
+under a heading for the current month.
+Include this description in the PR
+that contains your change.
+
+Consult the existing document
+for a sense of what sort of changes
+justify inclusion in `RECENT_CHANGES.md`,
+and for how to write a good description.
+
+As a reviewer,
+be sure to review `RECENT_CHANGES.md` additions as well —
+and if the submitter didn't write one,
+be sure to consider whether they should.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+If you're interested in contributing to this project,
+please read the
+[general PDC contribution guidelines](https://github.com/PhilanthropyDataCommons/.github/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds the `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` files that govern contributions and participant conduct.

As per multiple discussions, individual repos will contain links to the shared versions in the PDC `.github` repository, plus any repo-specific instructions.

Closes #251