### PR TITLE
Redirect from pilot.pdco to app.pdco

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,10 @@
 # Recent Changes to the PDC
 
+## November 2023
+
+- Renamed the domain from `pilot.philanthropydatacommons.org`
+  to `app.philanthropydatacommons.org`
+
 ## June 2023
 
 - Add the ability to show applicant data from data platform providers,

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# Move from pilot.pdco to app.pdco
+https://pilot.philanthropydatacommons.org/* https://app.philanthropydatacommons.org/:splat 301!


### PR DESCRIPTION
Configure Netlify to redirect requests.

Netlify allows [redirects between the domains of an app](https://docs.netlify.com/domains-https/custom-domains/multiple-domains/#domain-redirects) by using the [`_redirects` file](https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects).

This should not be merged until DNS is configured and confirmed working!

Issue #333 Change subdomain from pilot to app