### PR TITLE
Refactor to new react-router data router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Layout } from './Layout';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
@@ -8,14 +8,16 @@ import { Landing } from './pages/Landing';
 import './App.css';
 
 const App = () => (
-  <Routes>
-    <Route element={<Layout />}>
-      <Route path="/" element={<Landing />} />
-      <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
-      <Route path="/proposals" element={<ProposalList />} />
-      <Route path="*" element={<NotFound />} />
-    </Route>
-  </Routes>
+  <BrowserRouter>
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<Landing />} />
+        <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
+        <Route path="/proposals" element={<ProposalList />} />
+        <Route path="*" element={<NotFound />} />
+      </Route>
+    </Routes>
+  </BrowserRouter>
 );
 
 export { App };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import './App.css';
 
 const Root = () => (
   <Routes>
-    <Route path="/" element={<Landing />} />
     <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
     <Route path="/proposals" element={<ProposalList />} />
     <Route path="*" element={<NotFound />} />
@@ -22,6 +21,7 @@ const router = createBrowserRouter([
   {
     Component: Layout,
     children: [
+      { path: '/', Component: Landing },
       { path: '*', Component: Root },
     ],
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import './App.css';
 
 const Root = () => (
   <Routes>
-    <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
     <Route path="/proposals" element={<ProposalList />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
@@ -22,6 +21,7 @@ const router = createBrowserRouter([
     Component: Layout,
     children: [
       { path: '/', Component: Landing },
+      { path: '/proposals/:proposalId/provider?/:provider?', Component: ProposalDetail },
       { path: '*', Component: Root },
     ],
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import './App.css';
 
 const Root = () => (
   <Routes>
-    <Route path="/proposals" element={<ProposalList />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );
@@ -22,6 +21,7 @@ const router = createBrowserRouter([
     children: [
       { path: '/', Component: Landing },
       { path: '/proposals/:proposalId/provider?/:provider?', Component: ProposalDetail },
+      { path: '/proposals', Component: ProposalList },
       { path: '*', Component: Root },
     ],
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import {
+  createBrowserRouter, Route, Routes, RouterProvider,
+} from 'react-router-dom';
 import { Layout } from './Layout';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
@@ -7,17 +9,23 @@ import { ProposalList } from './pages/ProposalList';
 import { Landing } from './pages/Landing';
 import './App.css';
 
+const Root = () => (
+  <Routes>
+    <Route element={<Layout />}>
+      <Route path="/" element={<Landing />} />
+      <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
+      <Route path="/proposals" element={<ProposalList />} />
+      <Route path="*" element={<NotFound />} />
+    </Route>
+  </Routes>
+);
+
+const router = createBrowserRouter([
+  { path: '*', Component: Root },
+]);
+
 const App = () => (
-  <BrowserRouter>
-    <Routes>
-      <Route element={<Layout />}>
-        <Route path="/" element={<Landing />} />
-        <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
-        <Route path="/proposals" element={<ProposalList />} />
-        <Route path="*" element={<NotFound />} />
-      </Route>
-    </Routes>
-  </BrowserRouter>
+  <RouterProvider router={router} />
 );
 
 export { App };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
-import {
-  createBrowserRouter, Route, Routes, RouterProvider,
-} from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Layout } from './Layout';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
 import { ProposalList } from './pages/ProposalList';
 import { Landing } from './pages/Landing';
 import './App.css';
-
-const Root = () => (
-  <Routes>
-    <Route path="*" element={<NotFound />} />
-  </Routes>
-);
 
 const router = createBrowserRouter([
   {
@@ -22,7 +14,7 @@ const router = createBrowserRouter([
       { path: '/', Component: Landing },
       { path: '/proposals/:proposalId/provider?/:provider?', Component: ProposalDetail },
       { path: '/proposals', Component: ProposalList },
-      { path: '*', Component: Root },
+      { path: '*', Component: NotFound },
     ],
   },
 ]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,17 +11,20 @@ import './App.css';
 
 const Root = () => (
   <Routes>
-    <Route element={<Layout />}>
-      <Route path="/" element={<Landing />} />
-      <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
-      <Route path="/proposals" element={<ProposalList />} />
-      <Route path="*" element={<NotFound />} />
-    </Route>
+    <Route path="/" element={<Landing />} />
+    <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
+    <Route path="/proposals" element={<ProposalList />} />
+    <Route path="*" element={<NotFound />} />
   </Routes>
 );
 
 const router = createBrowserRouter([
-  { path: '*', Component: Root },
+  {
+    Component: Layout,
+    children: [
+      { path: '*', Component: Root },
+    ],
+  },
 ]);
 
 const App = () => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { AppHeader } from './components/AppHeader';
-import { AppMain } from './components/AppMain';
+import { Layout } from './Layout';
 import { NotFound } from './pages/NotFound';
 import { ProposalDetail } from './pages/ProposalDetail';
 import { ProposalList } from './pages/ProposalList';
@@ -9,17 +8,14 @@ import { Landing } from './pages/Landing';
 import './App.css';
 
 const App = () => (
-  <div className="App">
-    <AppHeader />
-    <AppMain>
-      <Routes>
-        <Route path="/" element={<Landing />} />
-        <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
-        <Route path="/proposals" element={<ProposalList />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </AppMain>
-  </div>
+  <Routes>
+    <Route element={<Layout />}>
+      <Route path="/" element={<Landing />} />
+      <Route path="/proposals/:proposalId/provider?/:provider?" element={<ProposalDetail />} />
+      <Route path="/proposals" element={<ProposalList />} />
+      <Route path="*" element={<NotFound />} />
+    </Route>
+  </Routes>
 );
 
 export { App };

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { AppHeader } from './components/AppHeader';
+import { AppMain } from './components/AppMain';
+
+const Layout = () => (
+  <div className="App">
+    <AppHeader />
+    <AppMain>
+      <Outlet />
+    </AppMain>
+  </div>
+);
+
+export { Layout };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import { OidcProvider } from '@axa-fr/react-oidc';
 import { App } from './App';
 import { getConfiguration } from './oidc-config';
@@ -25,9 +24,7 @@ if (rootElement) {
   root.render(
     <React.StrictMode>
       <OidcProvider configuration={configuration}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <App />
       </OidcProvider>
     </React.StrictMode>,
   );


### PR DESCRIPTION
The React Router documentation [recommends](https://reactrouter.com/en/main/routers/create-browser-router) using the new data router approach for all projects. This is a fairly faithful and simple refactoring following the [migration guide](https://reactrouter.com/en/main/upgrading/v6-data). It should have all the same behavior as the existing application, and would allow us to use the new APIs that are only available in data router apps.