### PR TITLE
Show Storybook icon on deploy previews

### DIFF
--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { EnvelopeIcon } from '@heroicons/react/24/outline';
+import { BookOpenIcon, EnvelopeIcon } from '@heroicons/react/24/outline';
 import { TableCellsIcon } from '@heroicons/react/24/solid';
 import { User } from './User';
 
@@ -13,6 +13,14 @@ const AppNavbar = () => (
           Dashboard
         </NavLink>
       </li>
+      {process.env.REACT_APP_SHOW_STORYBOOK === 'true' && (
+        <li>
+          <a href="/storybook" className="App-navbar__item">
+            <BookOpenIcon />
+            Storybook
+          </a>
+        </li>
+      )}
       <li>
         <a
           href="mailto:info@philanthropydatacommons.org?Subject=Feedback%20on%20the%20Philanthropy%20Data%20Commons"


### PR DESCRIPTION
We are using Netlify to build and deploy the front-end, and it is able to deploy pull requests to temporary domains. Often, one of the things we want to check on a deploy preview is that our components look good in Storybook - and, indeed, that Storybook is working correctly.

Previously, after Netlify gave us a deploy preview, we would follow the link it posted in the PR and then manually add `/storybook` to the end. Now, there can be a link in the app!

The link only renders when the app is built with the environment variable `REACT_APP_SHOW_STORYBOOK` set to the value `true` - otherwise, and by default, the new navbar icon will not be shown. Netlify allows for deploy-preview-only environment variables, and I have configured it to activate this feature.

Note also this won't really work with `npm start`: the link will render, but since the dev server doesn't know about Storybook, you'll get the 404 handler.