### PR TITLE
Fix GitHub Actions check name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
 jobs:
-  run_tests:
+  run_build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In a bit of what I presume was copy-pasta, the job for building the application was misnamed. This text is user-visible in the GitHub pull request status, where it lists the checks that have passed or failed.

This recently confused me!