### PR TITLE
Create bulk upload file-picking component

### DIFF
--- a/src/components/BulkUploaderFilePicker.css
+++ b/src/components/BulkUploaderFilePicker.css
@@ -1,0 +1,102 @@
+:root {
+  --file-picker--background-color: var(--color--gray--lighter);
+  --file-picker--color: var(--color--gray--darker);
+  --file-picker--border: 1px solid var(--color--gray--medium);
+  --file-picker--max-width: none;
+  --file-picker--button--cursor: pointer;
+  --file-picker--icon-size: 3rem;
+}
+
+.file-picker {
+  max-width: var(--file-picker--max-width);
+}
+
+.file-picker.dragging {
+  --file-picker--background-color: var(--color--gray--light);
+  --file-picker--border: 3px dotted var(--color--gray--medium);
+}
+
+.file-picker.uploading {
+  --file-picker--border: 3px dotted var(--color--gray);
+  --file-picker--button--cursor: default;
+}
+
+.file-picker.uploading.dragging {
+  --file-picker--button--cursor: no-drop;
+}
+
+.file-picker.error {
+  --file-picker--border: 3px dotted var(--color--gray--light);
+  --file-picker--color: var(--color--red);
+}
+
+.file-picker button {
+  all: unset;
+  box-sizing: border-box;
+  cursor: var(--file-picker--button--cursor);
+
+  display: grid;
+  place-items: center;
+  text-align: center;
+  aspect-ratio: 1;
+  width: 100%;
+  padding: var(--fixed-spacing--1x);
+  background-color: var(--file-picker--background-color);
+  color: var(--file-picker--color);
+  font-weight: var(--font-weight--medium);
+  border: var(--file-picker--border);
+  border-radius: 10px;
+
+  transition-duration: var(--transition-duration--cursor);
+  transition-property: background-color, border, color, outline;
+}
+
+/* Prevent markup within the label from blocking drag events. */
+.file-picker button > * {
+  pointer-events: none;
+}
+
+.file-picker button:focus {
+  outline: 2px solid blue;
+}
+
+.file-picker input[type="file"] {
+  display: none;
+}
+
+.file-picker-message {
+  display: flex;
+  flex-direction: column;
+  gap: var(--accessible-spacing--1x);
+  align-items: center;
+  text-align: center;
+}
+
+.file-picker-message__icon {
+  /* For SVG icons: */
+  width: var(--file-picker--icon-size);
+  height: var(--file-picker--icon-size);
+  aspect-ratio: 1;
+
+  /* For other components: */
+  --spinner--size: var(--file-picker--icon-size);
+}
+
+.complete .file-picker-message__icon {
+  color: var(--color--green);
+}
+
+.file-picker-message__text {
+  color: var(--file-picker--color);
+  font-weight: var(--font-weight--medium); 
+}
+
+.file-picker-message__additional-text {
+  font-weight: var(--font-weight--normal); 
+}
+
+.file-picker-message__reset-link {
+  font-weight: var(--font-weight--normal); 
+  color: var(--color--blue--dark);
+  text-decoration: underline;
+}

--- a/src/components/BulkUploaderFilePicker.tsx
+++ b/src/components/BulkUploaderFilePicker.tsx
@@ -1,0 +1,352 @@
+import React, {
+  ChangeEventHandler,
+  DragEventHandler,
+  MouseEventHandler,
+  useRef,
+  useState,
+} from 'react';
+import {
+  CheckCircleIcon,
+  DocumentPlusIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline';
+import { DocumentArrowUpIcon } from '@heroicons/react/24/solid';
+import './BulkUploaderFilePicker.css';
+import { Spinner } from './Spinner';
+
+interface FilePickerMessageProps {
+  text: React.ReactNode;
+  icon?: React.ReactNode | null;
+  additionalText?: React.ReactNode | null;
+  resetLink?: boolean;
+}
+
+const FilePickerMessage = ({
+  text = '',
+  icon = null,
+  additionalText = null,
+  resetLink = false,
+}: FilePickerMessageProps) => (
+  <div className="file-picker-message">
+    {icon && (
+      <span className="file-picker-message__icon">
+        {icon}
+      </span>
+    )}
+    <span className="file-picker-message__text">
+      {text}
+    </span>
+    {additionalText && (
+      <span className="file-picker-message__additional-text">
+        {additionalText}
+      </span>
+    )}
+    {resetLink && (
+      <span className="file-picker-message__reset-link">
+        Reset uploader
+      </span>
+    )}
+  </div>
+);
+
+export const BulkUploaderFilePicker = () => {
+  const ACCEPTED_MIME_TYPES = ['text/csv'];
+  const ACCEPTED_FILE_EXTENSIONS = ['csv'];
+  const MAXIMUM_FILE_SIZE_BYTES = 1e+9; // 1GB
+
+  const DEFAULT_STATUS = 'idle';
+
+  const formRef = useRef<HTMLFormElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [status, setStatus] = useState(DEFAULT_STATUS);
+
+  const statusClass = status.split('.').at(0) ?? DEFAULT_STATUS;
+  const isDragging = statusClass === 'dragging';
+  const isUploading = statusClass === 'uploading';
+  const isComplete = statusClass === 'complete';
+  const hasError = statusClass === 'error';
+
+  /**
+   * Provided a list of files,
+   * performs pre-upload validations.
+   *
+   * @param  {FileList | null} files
+   */
+  const validateFiles = (files: FileList | null) => {
+    if (!files?.[0]) {
+      setStatus('error.noFile');
+      return false;
+    }
+
+    if (files.length > 1) {
+      setStatus('error.maxFileCount');
+      return false;
+    }
+
+    const file = files[0];
+
+    const fileExtension = file.name.split('.').at(-1) ?? '';
+    if (
+      !ACCEPTED_MIME_TYPES.includes(file.type)
+      || !ACCEPTED_FILE_EXTENSIONS.includes(fileExtension)
+    ) {
+      setStatus('error.unsupportedType');
+      return false;
+    }
+
+    if (file.size > MAXIMUM_FILE_SIZE_BYTES) {
+      setStatus('error.maxFileSize');
+      return false;
+    }
+
+    return true;
+  };
+
+  /**
+   * Provided a list of files
+   * from either a native file picker
+   * or the Drag and Drop API,
+   * validates and uploads the files.
+   *
+   * @param  {FileList | null} files
+   */
+  const handleFiles = (files: FileList | null) => {
+    if (!validateFiles(files)) {
+      return;
+    }
+
+    // Remove focus from the button.
+    // We wait until after validation
+    // so focus is not wrenched away.
+    buttonRef.current?.blur();
+
+    setStatus('uploading');
+
+    // TODO: Begin uploading
+  };
+
+  /**
+   * Handler for when a dragged file enters the component.
+   *
+   * @param  {DragEventHandler} e
+   */
+  const handleDragEnter: DragEventHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (isUploading) return;
+
+    setStatus('dragging');
+  };
+
+  /**
+   * Handler for when a dragged file leaves the component.
+   *
+   * @param  {DragEventHandler} e
+   */
+  const handleDragLeave: DragEventHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (isUploading) return;
+
+    setStatus('idle');
+  };
+
+  /**
+   * Handler for the event that is fired constantly
+   * while the user is holding the file over the component.
+   *
+   * We have to make this a no-op
+   * so that dropping works consistently.
+   *
+   * @param  {DragEventHandler} e
+   */
+  const handleDragOver: DragEventHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  const handleDrop: DragEventHandler = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (isUploading) return;
+
+    const { files } = e.dataTransfer;
+    handleFiles(files);
+  };
+
+  /**
+   * Proxy clicks on the button element
+   * to the input file element
+   * so that clicking the button
+   * opens the native file-picker.
+   *
+   * @param  {MouseEventHandler} e
+   */
+  const handleProxyClick: MouseEventHandler = () => {
+    if (isUploading) return;
+
+    // Reset the component when users click on it
+    // in an error state. This is an "escape hatch"
+    // for users who don't realize they can just
+    // drag and drop a new file.
+    if (hasError) {
+      setStatus(DEFAULT_STATUS);
+      return;
+    }
+
+    fileInputRef.current?.click();
+  };
+
+  /**
+   * Handler for when a file is selected
+   * using the native OS file picker.
+   *
+   * This is a backup for users
+   * having trouble with drag and drop
+   *
+   * @param  {ChangeEventHandler} e
+   */
+  const handleFileInputChange: ChangeEventHandler = (e) => {
+    e.preventDefault();
+
+    const fileInput = e.target as HTMLInputElement;
+    handleFiles(fileInput.files);
+  };
+
+  /**
+   * Generate a comma-delimited list of valid file types
+   * for the native file picker. This list conforms to the
+   * spec for the `accept` HTML attribute.
+   *
+   * @return {string} Contents for the file input's `accept` attribute
+   */
+  const makeAcceptableFileAttr = () => {
+    // It's more sensible and flexible to list our file extensions without the
+    // dot. Since the `accept` attribute requires it, we add it here.
+    const prefixedFileExtensions = ACCEPTED_FILE_EXTENSIONS.map((ext) => `.${ext}`);
+
+    return prefixedFileExtensions.concat(ACCEPTED_MIME_TYPES).join(',');
+  };
+
+  /**
+   * Render the appropriate FilePickerMessage
+   * based on the current status.
+   *
+   * @return {FilePickerMessage}
+   */
+  const renderFilePickerMessage = () => {
+    if (isDragging) {
+      return (
+        <FilePickerMessage
+          icon={<DocumentArrowUpIcon className="icon" />}
+          text="Drop your file to begin uploading."
+        />
+      );
+    }
+
+    if (isUploading) {
+      return (
+        <FilePickerMessage
+          icon={<Spinner />}
+          text="Uploading your file…"
+        />
+      );
+    }
+
+    if (isComplete) {
+      return (
+        <FilePickerMessage
+          icon={<CheckCircleIcon className="icon" />}
+          text="Upload complete!"
+          additionalText={`
+            We are now processing your file.
+            Come back to this page any time
+            to check the progress below.
+          `}
+        />
+      );
+    }
+
+    if (hasError) {
+      const error = status.split('.').at(1);
+      switch (error) {
+        case 'maxFileCount':
+          return (
+            <FilePickerMessage
+              icon={<XCircleIcon className="icon" />}
+              text="You can only upload one file at a time."
+              resetLink
+            />
+          );
+        case 'maxFileSize':
+          return (
+            <FilePickerMessage
+              icon={<XCircleIcon className="icon" />}
+              text="Your file is too large"
+              // TODO: Use a formatting utility to generate "1GB".
+              additionalText="You can only upload 1GB at a time."
+              resetLink
+            />
+          );
+        case 'unsupportedType':
+          return (
+            <FilePickerMessage
+              icon={<XCircleIcon className="icon" />}
+              text="Unsupported file type"
+              additionalText="Your file must be a CSV."
+              resetLink
+            />
+          );
+        case 'generic':
+        default:
+          return (
+            <FilePickerMessage
+              icon={<XCircleIcon className="icon" />}
+              text="Error uploading your file"
+              resetLink
+            />
+          );
+      }
+    }
+
+    return (
+      <FilePickerMessage
+        icon={<DocumentPlusIcon className="icon" />}
+        text="Drag and drop your CSV file here."
+      />
+    );
+  };
+
+  return (
+    <form
+      ref={formRef}
+      className={`file-picker ${statusClass}`}
+    >
+      {/* This is a button so it can receive keyboard focus. */}
+      <button
+        type="button"
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onClick={handleProxyClick}
+        disabled={isUploading}
+      >
+        {renderFilePickerMessage()}
+      </button>
+      {/* This is a native file input so the native file picker can be used as a fallback. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={makeAcceptableFileAttr()}
+        onChange={handleFileInputChange}
+        disabled={isUploading}
+      />
+    </form>
+  );
+};

--- a/src/components/Spinner.css
+++ b/src/components/Spinner.css
@@ -1,0 +1,46 @@
+:root {
+  --spinner--size: var(--accessible-spacing--4x);
+  --spinner--weight: calc(var(--spinner--size) / 10);
+  --spinner--color: var(--color--gray--darker);
+}
+
+.spinner {
+  position: relative;
+  display: inline-flex;
+  width: var(--spinner--size);
+  height: var(--spinner--size);
+  aspect-ratio: 1;
+}
+
+.spinner > div {
+  position: absolute;
+  width: var(--spinner--size);
+  height: var(--spinner--size);
+  aspect-ratio: 1;
+  animation: spinner 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border-width: var(--spinner--weight);
+  border-style: solid;
+  border-radius: 50%;
+  border-color: var(--spinner--color) transparent transparent transparent;
+}
+
+.spinner > div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+
+.spinner > div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+
+.spinner > div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './Spinner.css';
+
+export const Spinner = () => (
+  <div className="spinner">
+    <div />
+    <div />
+    <div />
+    <div />
+  </div>
+);

--- a/src/index.css
+++ b/src/index.css
@@ -3,11 +3,13 @@
   --color--gray--dark: #444;
   --color--gray--medium-dark: #757575;
   --color--gray--medium: #BBB;
+  --color--gray: #D7D7D7;
   --color--gray--light: #EFEFEF;
   --color--gray--lighter: #FAFAFA;
   --color--blue--dark: #0B5C96;
   --color--blue: #1176BC;
   --color--blue--lighter: #e7f5fe;
+  --color--green: #007f20;
   --color--red--dark: #701F1F;
   --color--red: #892929;
 

--- a/src/stories/BulkUploaderFilePicker.stories.tsx
+++ b/src/stories/BulkUploaderFilePicker.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
+
+const meta = {
+  component: BulkUploaderFilePicker,
+  tags: ['autodocs'],
+} satisfies Meta<typeof BulkUploaderFilePicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/stories/Spinner.stories.tsx
+++ b/src/stories/Spinner.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Spinner } from '../components/Spinner';
+
+const meta = {
+  component: Spinner,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};


### PR DESCRIPTION
This PR adds the component for picking a file from the filesystem to use for bulk upload. It supports both drag-and-drop and clicking to load the OS's native file-picker. (We don't call attention to the latter; it's a fallback. You can also activate it  via keyboard by tabbing to the component.) There is also some very basic validation, with TODOs for more/better.

https://github.com/PhilanthropyDataCommons/front-end/assets/4731/27de9f43-067b-4219-8383-0cc52fcaea11

This implementation is focused on our needs for the bulk uploader. I've thought about how it can be made into a more generic uploader, but decided we should wait until we have a second use case. Still, if there are obvious ways we can prepare for the future with a different component architecture, please suggest them.

**Testing:**
1. Load the `BulkUploaderFilePicker` component in Storybook
2. Click on the element and pick a file from the filesystem; note that it should only let you pick one file at a time, and it should limit you to picking `.csv` files.
3. Refresh the component.
4. Drag various files / combinations of files onto the component.
   - Dragging multiple files should generate an error.
   - Dragging a non-CSV file should generate an error.
   - Dragging a file larger than 1GB should generate an error. (This is currently a naive implementation that we can improve; also, the error message is not dynamic, but I punted on that until I add a byte-formatting utility for #413.)
   - Dragging a properly-sized CSV file should start the Uploading spinner.
   - Feel free to trick the component into a `Complete` status to see what that looks like.

Closes #411