### PR TITLE
Redirect from pilot.pdco to app.pdco (again)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,0 @@
-# Move from pilot.pdco to app.pdco
-https://pilot.philanthropydatacommons.org/* https://app.philanthropydatacommons.org/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,6 @@
 # https://docs.netlify.com/routing/redirects/
 
+# Move from pilot.pdco to app.pdco
+https://pilot.philanthropydatacommons.org/* https://app.philanthropydatacommons.org/:splat 301!
+
 /*  /index.html  200


### PR DESCRIPTION
Configure Netlify to redirect requests.

PR #420 put the new redirection in the wrong place. Move it to the already-existing redirects file.

This file is read top-to-bottom, so put it above the single-page-app directive.

- https://docs.netlify.com/routing/redirects/
- https://docs.netlify.com/domains-https/custom-domains/multiple-domains/#domain-redirects
- https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects

Issue #333 Change subdomain from pilot to app