### PR TITLE
Add data instructions and base fields table

### DIFF
--- a/src/components/AddDataInstructions.css
+++ b/src/components/AddDataInstructions.css
@@ -1,0 +1,3 @@
+.add-data-instructions {
+  max-width: 80ch;
+}

--- a/src/components/AddDataInstructions.tsx
+++ b/src/components/AddDataInstructions.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import './AddDataInstructions.css';
 import { Panel, PanelBody } from './Panel';
 
+const apiUrl = new URL('/', process.env.REACT_APP_API_URL);
+const bulkUploadTemplateUrl = new URL('/static/bulkUpload.csv', apiUrl);
+
 interface AddDataInstructionsProps {
   children?: React.ReactNode;
 }
@@ -11,7 +14,54 @@ export const AddDataInstructions = ({
 }: AddDataInstructionsProps) => (
   <Panel>
     <PanelBody>
-      <p>TODO: add data instructions</p>
+      <article className="add-data-instructions">
+        <h3>Add data to the PDC</h3>
+
+        <p>
+          <b>Adding data via the bulk uploader</b>
+          {' '}
+          is drag-and-drop easy:
+        </p>
+
+        <ol>
+          <li>
+            Create a CSV of your data with base field keys as the first row
+            (see table below). If you want, you can start with
+            {' '}
+            <a href={bulkUploadTemplateUrl.toString()}>
+              this template of recommended base fields
+            </a>
+            .
+          </li>
+          <li>
+            Upload your CSV in the sidebar to the left.
+          </li>
+        </ol>
+
+        <p>
+          Note that you cannot create new base fields via the bulk uploader.
+          Any columns in your file that don’t match an existing base field will
+          cause an error.
+        </p>
+
+        <p>
+          <b>Adding data via the API</b>
+          {' '}
+          allows the most control. You can create new opportunities,
+          add applications, register new base fields, and more.
+          To use the API, request an API key from
+          {' '}
+          <a href="mailto:info@philanthropydatacommons.org?Subject=PDC%20API%20key%20request">
+            info@philanthropydatacommons.org
+          </a>
+          {' '}
+          and then visit the documentation site at
+          {' '}
+          <a href={apiUrl.toString()}>{apiUrl.hostname}</a>
+          .
+        </p>
+      </article>
+
       {children}
     </PanelBody>
   </Panel>

--- a/src/components/AddDataInstructions.tsx
+++ b/src/components/AddDataInstructions.tsx
@@ -62,7 +62,21 @@ export const AddDataInstructions = ({
         </p>
       </article>
 
-      {children}
+      <article>
+        <header className="add-data-instructions">
+          <h3>Base Fields</h3>
+
+          <p>
+            Base fields are the backbone of the PDC. Your data must write to an
+            existing base field, unless you create a new one using the
+            {' '}
+            <a href={apiUrl.toString()}>API</a>
+            .
+          </p>
+        </header>
+
+        {children}
+      </article>
     </PanelBody>
   </Panel>
 );

--- a/src/components/BaseFields.css
+++ b/src/components/BaseFields.css
@@ -1,0 +1,5 @@
+.base-field-short-code {
+  display: block;
+  max-width: 50ch;
+  word-wrap: break-word;
+}

--- a/src/components/BaseFields.tsx
+++ b/src/components/BaseFields.tsx
@@ -1,18 +1,59 @@
 import React from 'react';
 import './BaseFields.css';
 import { ApiBaseField } from '../pdc-api';
+import {
+  Table,
+  TableHead,
+  ColumnHead,
+  TableBody,
+  TableRow,
+  RowCell,
+} from './Table';
+
+interface BaseFieldListTableRowProps {
+  field: ApiBaseField;
+}
+
+const BaseFieldListTableRow = ({
+  field,
+}: BaseFieldListTableRowProps) => (
+  <TableRow>
+    <RowCell>
+      <code className="base-field-short-code">
+        {field.shortCode}
+      </code>
+    </RowCell>
+    <RowCell>
+      {field.label}
+    </RowCell>
+    <RowCell>
+      {field.description}
+    </RowCell>
+  </TableRow>
+);
 
 interface BaseFieldsProps {
   fields: ApiBaseField[];
-  loading?: boolean;
 }
 
-/* eslint-disable @typescript-eslint/no-unused-vars, arrow-body-style */
 export const BaseFields = ({
   fields,
-  loading = false,
-}: BaseFieldsProps) => {
-  return (
-    <p>TODO: base fields list</p>
-  );
-};
+}: BaseFieldsProps) => (
+  <Table>
+    <TableHead fixed>
+      <TableRow>
+        <ColumnHead>Key</ColumnHead>
+        <ColumnHead>Label</ColumnHead>
+        <ColumnHead>Description</ColumnHead>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {fields.map((field) => (
+        <BaseFieldListTableRow
+          key={field.id}
+          field={field}
+        />
+      ))}
+    </TableBody>
+  </Table>
+);

--- a/src/map-proposals.test.ts
+++ b/src/map-proposals.test.ts
@@ -9,21 +9,25 @@ const baseFields: ApiBaseField[] = [
     id: 1,
     label: 'Organization Name',
     shortCode: 'organization_name',
+    description: 'Common name of the organization',
   },
   {
     id: 2,
     label: 'Organization City',
     shortCode: 'organization_city',
+    description: 'City of the organization',
   },
   {
     id: 3,
     label: 'Organization Contact',
     shortCode: 'organization_contact',
+    description: 'Person contact regarding this organization',
   },
   {
     id: 4,
     label: 'Organization Budget',
     shortCode: 'organization_budget',
+    description: 'Annual budget of the organization',
   },
 ];
 

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -19,7 +19,7 @@ const BaseFieldsLoader = () => {
   const fields = useBaseFields();
   if (fields === null) {
     return (
-      <BaseFields fields={[]} loading />
+      <BaseFields fields={[]} />
     );
   }
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -51,6 +51,7 @@ const usePdcApi = <T>(
 };
 
 interface ApiBaseField {
+  description: string;
   id: number;
   label: string;
   shortCode: string;

--- a/src/stories/BaseFields.stories.tsx
+++ b/src/stories/BaseFields.stories.tsx
@@ -14,16 +14,24 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     fields: [
-      { id: 1, label: 'Organization Name', shortCode: 'organization_name' },
-      { id: 2, label: 'Proposal Summary', shortCode: 'proposal_summary' },
+      {
+        id: 1,
+        label: 'Organization Name',
+        shortCode: 'organization_name',
+        description: 'Common name of the organization',
+      },
+      {
+        id: 2,
+        label: 'Proposal Summary',
+        shortCode: 'proposal_summary',
+        description: "Summary of the proposal's purpose",
+      },
     ],
-    loading: false,
   },
 };
 
 export const Loading: Story = {
   args: {
     fields: [],
-    loading: true,
   },
 };


### PR DESCRIPTION
Add the text that @reefdog wrote describing the use of the add data page, and show the list of base fields.

![Screenshot of add data page with instructions at the top and the list of base fields below it and extending off the bottom](https://github.com/PhilanthropyDataCommons/front-end/assets/1494855/60fc1779-67ac-4437-896e-e67a4a04c417)

Unfortunately, we have some very long base field `shortCode`s, so the first column is wider than in the mockup in #418. As a follow-up, we may wish to introduce a truncation toggle as we did on the proposals list. Additionally, or possibly alternatively, we are meaning to do a base field review, so maybe we'll fix this display challenge by fixing the data.

Note that this code assumes the API is giving us descriptions, but that change has not yet been deployed to production. That works out because a missing key lookup evaluates to null, which is rendered just the same as the empty string the API would give us until descriptions have been written.

To review, manually edit your URL to `/add-data`, or visit the [add data page on the deploy preview](https://deploy-preview-449--philanthropy-data-commons-viewer.netlify.app/add-data); I've updated Keycloak to allow logging in from the deploy preview.

I believe this should not conflict with #443, but if it does I'll resolve any merge conflicts on whichever PR is merged second.

Resolves #417 
Resolves #418 