### PR TITLE
Improve base field guidance

### DIFF
--- a/src/components/AddDataInstructions.tsx
+++ b/src/components/AddDataInstructions.tsx
@@ -39,12 +39,6 @@ export const AddDataInstructions = ({
         </ol>
 
         <p>
-          Note that you cannot create new base fields via the bulk uploader.
-          Any columns in your file that don’t match an existing base field will
-          cause an error.
-        </p>
-
-        <p>
           <b>Adding data via the API</b>
           {' '}
           allows the most control. You can create new opportunities,

--- a/src/components/AddDataInstructions.tsx
+++ b/src/components/AddDataInstructions.tsx
@@ -25,8 +25,13 @@ export const AddDataInstructions = ({
 
         <ol>
           <li>
-            Create a CSV of your data with base field keys as the first row
-            (see table below). If you want, you can start with
+            Create a CSV of your data with
+            {' '}
+            <a href="#base-fields">
+              base field keys
+            </a>
+            {' '}
+            as the first row. If you want, you can start with
             {' '}
             <a href={bulkUploadTemplateUrl.toString()}>
               this template of recommended base fields
@@ -56,7 +61,7 @@ export const AddDataInstructions = ({
         </p>
       </article>
 
-      <article>
+      <article id="base-fields">
         <header className="add-data-instructions">
           <h3>Base Fields</h3>
 

--- a/src/components/AddDataInstructions.tsx
+++ b/src/components/AddDataInstructions.tsx
@@ -31,7 +31,17 @@ export const AddDataInstructions = ({
               base field keys
             </a>
             {' '}
-            as the first row. If you want, you can start with
+            as the first row.
+            {' '}
+            <strong>
+              The
+              {' '}
+              <code>proposal_submitter_email</code>
+              {' '}
+              field is required.
+            </strong>
+            {' '}
+            If you want, you can start with
             {' '}
             <a href={bulkUploadTemplateUrl.toString()}>
               this template of recommended base fields

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -81,8 +81,10 @@
 .panel-body {
   grid-row: 2;
   overflow: auto;
+  scroll-behavior: smooth;
 }
 
 .panel-body--padded {
   padding: var(--panel--padding);
+  scroll-padding-top: var(--panel--padding);
 }


### PR DESCRIPTION
This PR tweaks the bulk upload instructions to:

- offer less negative language by default
- include required field notice
- hold the user's hand by (smoothly) scrolling to the base field keys

Closes #463
Closes #464 