### PR TITLE
Upload bulk uploads to the API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/components/BulkUploaderFilePicker.tsx
+++ b/src/components/BulkUploaderFilePicker.tsx
@@ -49,7 +49,13 @@ const FilePickerMessage = ({
   </div>
 );
 
-export const BulkUploaderFilePicker = () => {
+interface BulkUploaderFilePickerProps {
+  uploadFile: (file: File) => Promise<void>;
+}
+
+export const BulkUploaderFilePicker = ({
+  uploadFile,
+}: BulkUploaderFilePickerProps) => {
   const ACCEPTED_MIME_TYPES = ['text/csv'];
   const ACCEPTED_FILE_EXTENSIONS = ['csv'];
   const MAXIMUM_FILE_SIZE_BYTES = 1e+9; // 1GB
@@ -74,7 +80,7 @@ export const BulkUploaderFilePicker = () => {
    *
    * @param  {FileList | null} files
    */
-  const validateFiles = (files: FileList | null) => {
+  const validateFiles = (files: FileList | null): files is FileList & { 0: File } => {
     if (!files?.[0]) {
       setStatus('error.noFile');
       return false;
@@ -105,10 +111,8 @@ export const BulkUploaderFilePicker = () => {
   };
 
   /**
-   * Provided a list of files
-   * from either a native file picker
-   * or the Drag and Drop API,
-   * validates and uploads the files.
+   * Provided a list of files from either a native file picker
+   * or the Drag and Drop API, validates and uploads the files.
    *
    * @param  {FileList | null} files
    */
@@ -118,13 +122,18 @@ export const BulkUploaderFilePicker = () => {
     }
 
     // Remove focus from the button.
-    // We wait until after validation
-    // so focus is not wrenched away.
+    // We wait until after validation so focus is not wrenched away.
     buttonRef.current?.blur();
 
     setStatus('uploading');
 
-    // TODO: Begin uploading
+    uploadFile(files[0])
+      .then(() => {
+        setStatus('complete');
+      })
+      .catch(() => {
+        setStatus('error.uploadFailure');
+      });
   };
 
   /**
@@ -302,12 +311,12 @@ export const BulkUploaderFilePicker = () => {
               resetLink
             />
           );
-        case 'generic':
+        case 'uploadFailure':
         default:
           return (
             <FilePickerMessage
               icon={<XCircleIcon className="icon" />}
-              text="Error uploading your file"
+              text="Error uploading your file. Please try again."
               resetLink
             />
           );

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -1,16 +1,40 @@
 import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import {
+  uploadUsingPresignedPost,
   useBaseFields,
   useBulkUploads,
+  usePresignedPostCallback,
+  useRegisterBulkUploadCallback,
 } from '../pdc-api';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { Panel, PanelBody } from '../components/Panel';
 import { AddDataInstructions } from '../components/AddDataInstructions';
 import { BaseFields } from '../components/BaseFields';
+import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
 import { BulkUploadList } from '../components/BulkUploadList';
 
-const BulkUploaderLoader = () => <p>TODO: bulk uploader</p>;
+const BulkUploaderLoader = () => {
+  const createPresignedPost = usePresignedPostCallback();
+  const registerBulkUpload = useRegisterBulkUploadCallback();
+  const handleUpload = async (file: File) => {
+    const { presignedPost } = await createPresignedPost({
+      fileType: file.type || 'application/octet-stream',
+      fileSize: file.size,
+    });
+
+    await uploadUsingPresignedPost(file, presignedPost);
+
+    await registerBulkUpload({
+      fileName: file.name,
+      sourceKey: presignedPost.fields.key,
+    });
+  };
+
+  return (
+    <BulkUploaderFilePicker uploadFile={handleUpload} />
+  );
+};
 
 const BulkUploadHistoryLoader = () => {
   const history = useBulkUploads();

--- a/src/stories/BulkUploaderFilePicker.stories.tsx
+++ b/src/stories/BulkUploaderFilePicker.stories.tsx
@@ -12,5 +12,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    uploadFile: async () => {},
+  },
 };


### PR DESCRIPTION
This PR:
- Adds a file handler to the file picker component
- Creates a presigned POST request
- Uploads the bulk upload to the service
- Marks the upload as complete once it is
- Marks the file picker with an error if the upload fails

It does not:

- Refresh the BulkUpload history with the new upload; user must refresh.
  - Opened as: #527

TODO:
- [ ] Sort out inconsistent upload issue
- ~Add RECENT_CHANGES note~ Edit: Actually, we shouldn't do this until we actually want users to use it, I.e. #438

🚨 **Reminder:** The `service` repo will need a production deployment before this is merged in. The [currently-deployed API](https://api.philanthropydatacommons.org) doesn't have `/bulkUploads` routes. 🚨

Closes #412
Closes #528