### PR TITLE
Refresh upload history

### DIFF
--- a/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
@@ -195,7 +195,7 @@ const ProviderPanelLoader = ({
   onClose,
   provider,
 }: ProviderPanelLoaderProps) => {
-  const allProviderData = useProviderData(externalId);
+  const [allProviderData] = useProviderData(externalId);
   if (allProviderData === null) {
     return <Loading onClose={onClose} provider={provider} />;
   }

--- a/src/components/NewBulkUploadPanel.tsx
+++ b/src/components/NewBulkUploadPanel.tsx
@@ -5,13 +5,13 @@ import './NewBulkUploadPanel.css';
 
 interface NewBulkUploadPanelProps {
   apiUrl: URL;
-  bulkUploaderLoader: React.ReactNode;
+  bulkUploader: React.ReactNode;
   baseFieldsLoader: React.ReactNode;
 }
 
 export const NewBulkUploadPanel = ({
   apiUrl,
-  bulkUploaderLoader,
+  bulkUploader,
   baseFieldsLoader,
 }: NewBulkUploadPanelProps) => {
   const bulkUploadTemplateUrl = new URL('/static/bulkUpload.csv', apiUrl);
@@ -59,7 +59,7 @@ export const NewBulkUploadPanel = ({
           </div>
 
           <div id="bulk-uploader-wrapper">
-            {bulkUploaderLoader}
+            {bulkUploader}
           </div>
         </section>
 

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -17,7 +17,7 @@ import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
 import { BulkUploadList } from '../components/BulkUploadList';
 import './AddData.css';
 
-const BulkUploaderLoader = () => {
+const BulkUploader = () => {
   const createPresignedPost = usePresignedPostCallback();
   const registerBulkUpload = useRegisterBulkUploadCallback();
   const handleUpload = async (file: File) => {
@@ -84,7 +84,7 @@ const AddDataLoader = () => {
       <PanelGridItem>
         <NewBulkUploadPanel
           apiUrl={new URL('/', process.env.REACT_APP_API_URL)}
-          bulkUploaderLoader={<BulkUploaderLoader />}
+          bulkUploader={<BulkUploader />}
           baseFieldsLoader={<BaseFieldsLoader />}
         />
       </PanelGridItem>

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -40,7 +40,7 @@ const BulkUploaderLoader = () => {
 };
 
 const BulkUploadHistoryLoader = () => {
-  const history = useBulkUploads();
+  const [history] = useBulkUploads();
 
   if (history === null) {
     return <BulkUploadList uploads={[]} />;
@@ -49,7 +49,7 @@ const BulkUploadHistoryLoader = () => {
 };
 
 const BaseFieldsLoader = () => {
-  const fields = useBaseFields();
+  const [fields] = useBaseFields();
   if (fields === null) {
     return (
       <BaseFields fields={[]} />

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -17,7 +17,25 @@ import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
 import { BulkUploadList } from '../components/BulkUploadList';
 import './AddData.css';
 
-const BulkUploader = () => {
+const BaseFieldsLoader = () => {
+  const [fields] = useBaseFields();
+  if (fields === null) {
+    return (
+      <BaseFields fields={[]} />
+    );
+  }
+
+  return (
+    <BaseFields fields={fields} />
+  );
+};
+
+interface BulkUploaderProps {
+  onBulkUpload: () => void;
+}
+const BulkUploader = ({
+  onBulkUpload,
+}: BulkUploaderProps) => {
   const createPresignedPost = usePresignedPostCallback();
   const registerBulkUpload = useRegisterBulkUploadCallback();
   const handleUpload = async (file: File) => {
@@ -32,36 +50,21 @@ const BulkUploader = () => {
       fileName: file.name,
       sourceKey: presignedPost.fields.key,
     });
+
+    onBulkUpload();
   };
 
   return (
-    <BulkUploaderFilePicker uploadFile={handleUpload} />
-  );
-};
-
-const BulkUploadHistoryLoader = () => {
-  const [history] = useBulkUploads();
-
-  if (history === null) {
-    return <BulkUploadList uploads={[]} />;
-  }
-  return <BulkUploadList uploads={history.entries} />;
-};
-
-const BaseFieldsLoader = () => {
-  const [fields] = useBaseFields();
-  if (fields === null) {
-    return (
-      <BaseFields fields={[]} />
-    );
-  }
-
-  return (
-    <BaseFields fields={fields} />
+    <BulkUploaderFilePicker
+      uploadFile={handleUpload}
+    />
   );
 };
 
 const AddDataLoader = () => {
+  const [bulkUploadResponse, refreshBulkUploads] = useBulkUploads();
+  const bulkUploads = bulkUploadResponse?.entries ?? [];
+
   useEffect(() => {
     document.title = 'Add Data - Philanthropy Data Commons';
   }, []);
@@ -77,14 +80,18 @@ const AddDataLoader = () => {
             </NavLink>
           </PanelHeader>
           <PanelBody padded={false}>
-            <BulkUploadHistoryLoader />
+            <BulkUploadList uploads={bulkUploads} />
           </PanelBody>
         </Panel>
       </PanelGridItem>
       <PanelGridItem>
         <NewBulkUploadPanel
           apiUrl={new URL('/', process.env.REACT_APP_API_URL)}
-          bulkUploader={<BulkUploader />}
+          bulkUploader={(
+            <BulkUploader
+              onBulkUpload={refreshBulkUploads}
+            />
+          )}
           baseFieldsLoader={<BaseFieldsLoader />}
         />
       </PanelGridItem>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -30,7 +30,7 @@ const ProposalListGridLoader = (
 ) => {
   const { proposalId } = useParams();
 
-  const proposals = useProposals(
+  const [proposals] = useProposals(
     PROPOSALS_DEFAULT_PAGE,
     PROPOSALS_DEFAULT_COUNT,
     PROPOSALS_DEFAULT_QUERY,
@@ -111,7 +111,7 @@ const ProposalDetailPanelLoader = (
   const params = useParams();
   const proposalId = params.proposalId ?? 'missing';
   const { provider } = params;
-  const proposal = useProposal(proposalId);
+  const [proposal] = useProposal(proposalId);
 
   useEffect(() => {
     if (baseFields === null || proposal === null) {
@@ -181,7 +181,7 @@ const ProposalDetailPanelLoader = (
 };
 
 const ProposalDetailLoader = () => {
-  const baseFields = useBaseFields();
+  const [baseFields] = useBaseFields();
 
   return (
     <PanelGrid sidebarred>

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -23,8 +23,8 @@ const ProposalListLoader = () => {
   const page = params.get('page') ?? PROPOSALS_DEFAULT_PAGE;
   const count = params.get('count') ?? PROPOSALS_DEFAULT_COUNT;
   const query = params.get('q') ?? PROPOSALS_DEFAULT_QUERY;
-  const fields = useBaseFields();
-  const proposals = useProposals(page, count, query);
+  const [fields] = useBaseFields();
+  const [proposals] = useProposals(page, count, query);
 
   useEffect(() => {
     document.title = 'Proposal List - Philanthropy Data Commons';

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -21,11 +21,11 @@ const logError = (error: unknown, path: string, params: object) => {
 const usePdcApi = <T>(
   path: string,
   params: URLSearchParams = new URLSearchParams(),
-): T | null => {
+): [T | null, () => void] => {
   const { fetch } = useOidcFetch();
   const [response, setResponse] = useState(null);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     setResponse(null);
     const url = new URL(path, API_URL);
     url.search = params.toString();
@@ -47,7 +47,14 @@ const usePdcApi = <T>(
      */
   }, [path, params.toString()]);
 
-  return response;
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return [
+    response,
+    fetchData,
+  ];
 };
 
 const usePdcCallbackApi = <T>(

--- a/src/stories/NewBulkUploadPanel.stories.tsx
+++ b/src/stories/NewBulkUploadPanel.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     apiUrl: new URL('http://localhost/'),
-    bulkUploaderLoader: <code>bulkUploaderLoader</code>,
+    bulkUploader: <code>bulkUploader</code>,
     baseFieldsLoader: <code>baseFieldsLoader</code>,
   },
 };


### PR DESCRIPTION
This PR changes the API hooks so that they expose the ability to re-run a given API call at a later time.  It also utilizes that new functionality to re-run the bulk upload list lookup every time the user creates a new bulk upload.

Resolves #527 