### PR TITLE
Add download attr to CSV template link

### DIFF
--- a/src/components/NewBulkUploadPanel.tsx
+++ b/src/components/NewBulkUploadPanel.tsx
@@ -51,7 +51,11 @@ export const NewBulkUploadPanel = ({
             </ul>
 
             <h2 className="label">Optional</h2>
-            <a href={bulkUploadTemplateUrl.toString()} className="has-icon no-visited">
+            <a
+              href={bulkUploadTemplateUrl.toString()}
+              className="has-icon no-visited"
+              download="pdc-bulk-upload-template"
+            >
               <DocumentDuplicateIcon className="icon" />
               Download CSV template of recommended base field keys
             </a>


### PR DESCRIPTION
On the bulk upload page, we link users to a CSV template hosted by the service repository. The service’s HTTP server gets to set the attachment disposition header that determines if the file is downloaded to disk or opened in-browser. Which is fine, and its prerogative! But we want *our* users to definitely download the file.

The `download` attribute to the rescue! We’ll also take this opportunity to set a value for the attribute, which will be the downloaded file’s filename.

There's no issue associated with this, as it's just a hotfix for something I noticed after #438 was merged and deployed.

**Testing:**
- Open deploy preview
- Log in (I will have added it to the Keycloak auth list)
- Go to the Add Data page
- Click the "Download CSV template of recommended base field keys" link
- On `main`/production, this will stream in-browser, but in this PR deploy preview, it will download to disk as `pdc-bulk-upload-template.csv`