### PR TITLE
Fix Bulk Upload List Refresh on File Upload 

### DIFF
--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { DocumentPlusIcon } from '@heroicons/react/24/outline';
@@ -63,11 +63,14 @@ const BulkUploader = ({
 
 const AddDataLoader = () => {
   const [bulkUploadResponse, refreshBulkUploads] = useBulkUploads();
-  const bulkUploads = bulkUploadResponse?.entries ?? [];
+  const [bulkUploads, setBulkUploads] = useState(bulkUploadResponse?.entries ?? []);
 
   useEffect(() => {
     document.title = 'Add Data - Philanthropy Data Commons';
-  }, []);
+    if (bulkUploadResponse?.entries) {
+      setBulkUploads(bulkUploadResponse.entries);
+    }
+  }, [bulkUploadResponse]);
 
   return (
     <PanelGrid sidebarred>


### PR DESCRIPTION
On the bulk upload page, when a user uploads a new file, the entire BulkUploadList component re-renders. This was fixed by using react state for the BulkUploads array that contains the metadata of the uploaded files. Now, on component update, only changed/added list items are re-rendered. 

Closes #572 

Testing:

Open dev instance
Log in 
Go to the Add Data page
Inspect the Bulk Upload History panel, and select a pre-existing component in the react-dev-tools inspector
Upload a new file, and verify that the pre-existing component was not re-rendered

