### PR TITLE
Add Poll API for bulk upload processing

### DIFF
--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -17,6 +17,8 @@ import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
 import { BulkUploadList } from '../components/BulkUploadList';
 import './AddData.css';
 
+const REFRESH_BULK_UPLOADS_INTERVAL = 5000;
+
 const BaseFieldsLoader = () => {
   const [fields] = useBaseFields();
   if (fields === null) {
@@ -67,10 +69,19 @@ const AddDataLoader = () => {
 
   useEffect(() => {
     document.title = 'Add Data - Philanthropy Data Commons';
+
     if (bulkUploadResponse?.entries) {
       setBulkUploads(bulkUploadResponse.entries);
     }
-  }, [bulkUploadResponse]);
+
+    const intervalId = setInterval(() => {
+      refreshBulkUploads();
+    }, REFRESH_BULK_UPLOADS_INTERVAL);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [bulkUploadResponse, refreshBulkUploads]);
 
   return (
     <PanelGrid sidebarred>


### PR DESCRIPTION
On the bulk upload page, when a user uploads a new file, the BulkUploadListItem will not update it's status until the page is refreshed. I have added a poll in the form of an interval set inside of the AddData page's useEffect hook that will poll the API every 2 seconds(a time amount I am open to changing, depending on group thought) and rerender any BulkUploadListItem's with changed status. I also added a callback function to the hook that clears the interval, so as to end the interval if the component ever dismounts. Based on my research this seems to be the convention when using setInterval.

Closes #415

Testing:

Open dev instance
Log in
Go to the Add Data page
Check the network tab in browser dev tools to verify a call to the backend is happening every 2 seconds
Upload a new file, verify that after it finishes uploading that is reflected in the bulk upload pannel