### PR TITLE
Decrease dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       timezone: "America/Los_Angeles"
-      time: "12:00"
+      time: "01:00"
+      day: "monday"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@types/node"


### PR DESCRIPTION
This PR changes dependabot to only run once a week for npm dependencies (I left the github ones at the same daily cadence since they are infrequent)

Resolves #591