### PR TITLE
Replace deprecated Heroicons icons

### DIFF
--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DocumentTextIcon } from '@heroicons/react/24/solid';
-import { ArrowRightOnRectangleIcon, CircleStackIcon } from '@heroicons/react/24/outline';
+import { ArrowRightStartOnRectangleIcon, CircleStackIcon } from '@heroicons/react/24/outline';
 import {
   Panel,
   PanelActions,
@@ -73,7 +73,7 @@ const ProposalDetailPanel = ({
             </DropdownMenuText>
             <DropdownMenuLink
               to={`/proposals/${proposalId}/provider/candid`}
-              icon={<ArrowRightOnRectangleIcon />}
+              icon={<ArrowRightStartOnRectangleIcon />}
               alignIcon="right"
               key="candid"
             >
@@ -81,7 +81,7 @@ const ProposalDetailPanel = ({
             </DropdownMenuLink>
             <DropdownMenuLink
               to={`/proposals/${proposalId}/provider/charity-navigator`}
-              icon={<ArrowRightOnRectangleIcon />}
+              icon={<ArrowRightStartOnRectangleIcon />}
               alignIcon="right"
               key="charity-navigator"
             >

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import {
-  ArrowRightOnRectangleIcon,
+  ArrowRightStartOnRectangleIcon,
   ArrowUpOnSquareIcon,
 } from '@heroicons/react/24/outline';
 
@@ -141,7 +141,7 @@ export const WithMenuItemIcons: Story = {
       <DropdownMenu>
         <DropdownMenuLink
           to="/"
-          icon={<ArrowRightOnRectangleIcon />}
+          icon={<ArrowRightStartOnRectangleIcon />}
           alignIcon="right"
           key="item1"
         >


### PR DESCRIPTION
Heroicons renamed one of their icons that we use. The old name has been deprecated and so intellisense ~strikes it out~. Let's replace.

**Testing:**
1. Open the dropdown in the [production "Dropdown → With Menu Item Icons" story](https://app.philanthropydatacommons.org/storybook/?path=/story/stories-dropdown--with-menu-item-icons) and note the icon.
2. Open that same dropdown in [this deploy preview's Storybook](https://deploy-preview-594--philanthropy-data-commons-viewer.netlify.app/storybook/?path=/story/stories-dropdown--with-menu-item-icons) and check the icon.
3. ✅ It's the same icon!

Closes #586