### PR TITLE
Group eslint dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
+      eslint:
+        patterns:
+          - '*eslint*'
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'


### PR DESCRIPTION
This PR adds an eslint grouping in dependabot so eslint related packages will get updated at the same time.