### PR TITLE
Implement proposal UI changes

### DIFF
--- a/src/components/ListGrid.tsx
+++ b/src/components/ListGrid.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 
+const LIST_GRID_ITEM_TRUNCATE_LENGTH = 30;
+
 interface ListGridProps<T> {
 	items: T[];
 	renderItem(item: T): React.ReactNode;
@@ -20,3 +22,5 @@ export const ListGrid = <T,>({ items, renderItem }: ListGridProps<T>) => {
 
 	return <div ref={listGridRef}>{items.map((item) => renderItem(item))}</div>;
 };
+
+export { LIST_GRID_ITEM_TRUNCATE_LENGTH };

--- a/src/components/ListGridItem.css
+++ b/src/components/ListGridItem.css
@@ -30,13 +30,8 @@
 	font-weight: var(--font-weight--medium);
 }
 
-.list-grid-item-applicant-address,
-.list-grid-item-proposal-name {
+.list-grid-item-detail{
 	color: var(--proposal-list-grid-item--details-color);
 	font-size: 0.9em;
 }
 
-.list-grid-item-organization-ein {
-	color: var(--proposal-list-grid-item--details-color);
-	font-size: 0.9em;
-}

--- a/src/components/ListGridItem.css
+++ b/src/components/ListGridItem.css
@@ -30,8 +30,7 @@
 	font-weight: var(--font-weight--medium);
 }
 
-.list-grid-item-detail{
+.list-grid-item-detail {
 	color: var(--proposal-list-grid-item--details-color);
 	font-size: 0.9em;
 }
-

--- a/src/components/Panel/PanelTitle.tsx
+++ b/src/components/Panel/PanelTitle.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const PANEL_TITLE_TRUNCATE_LENGTH = 50;
+
 interface PanelTitleProps {
 	children: React.ReactNode;
 	className?: string;
@@ -8,3 +10,5 @@ interface PanelTitleProps {
 export const PanelTitle = ({ children, className = '' }: PanelTitleProps) => (
 	<h1 className={`panel-title ${className}`.trim()}>{children}</h1>
 );
+
+export { PANEL_TITLE_TRUNCATE_LENGTH };

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
-import { DocumentTextIcon } from '@heroicons/react/24/solid';
-import {
-	ArrowRightStartOnRectangleIcon,
-	CircleStackIcon,
-} from '@heroicons/react/24/outline';
+import { BuildingOffice2Icon } from '@heroicons/react/24/solid';
 import {
 	Panel,
-	PanelActions,
 	PanelBody,
 	PanelHeader,
 	PanelTag,
@@ -15,19 +10,11 @@ import {
 	PanelTitleWrapper,
 } from './Panel';
 import { ProposalTable } from './ProposalTable';
-import {
-	Dropdown,
-	DropdownMenu,
-	DropdownMenuLink,
-	DropdownMenuText,
-	DropdownTrigger,
-} from './Dropdown';
 
 interface ProposalDetailPanelProps {
 	title: string | undefined;
 	applicant: string;
 	applicantId: string | undefined;
-	proposalId: number;
 	version: number;
 	values: {
 		shortCode: string;
@@ -38,7 +25,6 @@ interface ProposalDetailPanelProps {
 }
 
 const ProposalDetailPanel = ({
-	proposalId,
 	title,
 	applicant,
 	applicantId,
@@ -48,41 +34,14 @@ const ProposalDetailPanel = ({
 	<Panel>
 		<PanelHeader>
 			<PanelTitleWrapper>
-				<PanelTitle>{applicant}</PanelTitle>
+				<PanelTitle>{title ?? 'Untitled Proposal'}</PanelTitle>
 				<PanelTitleTags>
+					{applicant && (
+						<PanelTag icon={<BuildingOffice2Icon />}>{applicant}</PanelTag>
+					)}
 					{applicantId && <PanelTag badge="EIN">{applicantId}</PanelTag>}
-					{title && <PanelTag icon={<DocumentTextIcon />}>{title}</PanelTag>}
 				</PanelTitleTags>
 			</PanelTitleWrapper>
-			<PanelActions>
-				<Dropdown>
-					<DropdownTrigger>
-						<CircleStackIcon />
-						Data providers
-					</DropdownTrigger>
-					<DropdownMenu align="right">
-						<DropdownMenuText>
-							View applicant data from one of the data platform providers:
-						</DropdownMenuText>
-						<DropdownMenuLink
-							to={`/proposals/${proposalId}/provider/candid`}
-							icon={<ArrowRightStartOnRectangleIcon />}
-							alignIcon="right"
-							key="candid"
-						>
-							Candid
-						</DropdownMenuLink>
-						<DropdownMenuLink
-							to={`/proposals/${proposalId}/provider/charity-navigator`}
-							icon={<ArrowRightStartOnRectangleIcon />}
-							alignIcon="right"
-							key="charity-navigator"
-						>
-							Charity Navigator
-						</DropdownMenuLink>
-					</DropdownMenu>
-				</Dropdown>
-			</PanelActions>
 		</PanelHeader>
 		<PanelBody padded={false}>
 			<ProposalTable version={version} values={values} />

--- a/src/components/ProposalListGrid.tsx
+++ b/src/components/ProposalListGrid.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { getPreferredApplicantNameValues } from '../utils/proposals';
-import { ListGrid } from './ListGrid';
+import { LIST_GRID_ITEM_TRUNCATE_LENGTH, ListGrid } from './ListGrid';
 import './ListGridItem.css';
 
 interface ProposalListGridItemProps {
@@ -15,6 +15,11 @@ const ProposalListGridItem = ({
 	active = false,
 }: ProposalListGridItemProps) => {
 	const applicantName = getPreferredApplicantNameValues(proposal);
+	const title = proposal.values.proposal_name
+		? proposal.values.proposal_name
+		: proposal.values.proposal_summary
+				?.toString()
+				.substring(0, LIST_GRID_ITEM_TRUNCATE_LENGTH);
 
 	const applicantLocation = [
 		'organization_city',
@@ -30,16 +35,17 @@ const ProposalListGridItem = ({
 			to={`/proposals/${proposal.id}`}
 			className={`list-grid-item ${active ? 'active' : ''}`.trim()}
 		>
-			<div className="list-grid-item-applicant-name">{applicantName}</div>
+			{title ? (
+				<div className="list-grid-item-title">
+					{title}
+				</div>
+			) : (
+				<div className="list-grid-item-title">Untitled Proposal</div>
+			)}
+			<div className="list-grid-item-detail">{applicantName}</div>
+
 			{applicantLocation ? (
-				<div className="list-grid-item-applicant-address">
-					{applicantLocation}
-				</div>
-			) : null}
-			{proposal.values.proposal_name ? (
-				<div className="list-grid-item-proposal-name">
-					{proposal.values.proposal_name}
-				</div>
+				<div className="list-grid-item-detail">{applicantLocation}</div>
 			) : null}
 		</Link>
 	);

--- a/src/components/ProposalListGrid.tsx
+++ b/src/components/ProposalListGrid.tsx
@@ -36,9 +36,7 @@ const ProposalListGridItem = ({
 			className={`list-grid-item ${active ? 'active' : ''}`.trim()}
 		>
 			{title ? (
-				<div className="list-grid-item-title">
-					{title}
-				</div>
+				<div className="list-grid-item-title">{title}</div>
 			) : (
 				<div className="list-grid-item-title">Untitled Proposal</div>
 			)}

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -20,6 +20,7 @@ import {
 	PROPOSAL_APPLICANT_NAME_CASCADE,
 	PROPOSAL_APPLICANT_NAME_FALLBACK,
 } from '../utils/proposals';
+import { PANEL_TITLE_TRUNCATE_LENGTH } from '../components/Panel/PanelTitle';
 
 interface ProposalListGridLoaderProps {
 	baseFields: ApiBaseField[] | null;
@@ -126,7 +127,6 @@ const ProposalDetailPanelLoader = ({
 			<>
 				<PanelGridItem key="detailPanel">
 					<ProposalDetailPanel
-						proposalId={0}
 						title="Loading..."
 						applicant="Loading..."
 						applicantId="00-0000000"
@@ -149,7 +149,12 @@ const ProposalDetailPanelLoader = ({
 		);
 	}
 
-	const title = getValueOfBaseField(baseFields, proposal, 'proposal_name');
+	const title =
+		getValueOfBaseField(baseFields, proposal, 'proposal_name') ??
+		getValueOfBaseField(baseFields, proposal, 'proposal_summary')?.substring(
+			0,
+			PANEL_TITLE_TRUNCATE_LENGTH,
+		);
 	const applicant = getApplicant(baseFields, proposal);
 	const applicantId = getValueOfBaseField(
 		baseFields,
@@ -163,7 +168,6 @@ const ProposalDetailPanelLoader = ({
 		<>
 			<PanelGridItem key="detailPanel">
 				<ProposalDetailPanel
-					proposalId={proposal.id}
 					title={title}
 					applicant={applicant}
 					applicantId={applicantId}

--- a/src/stories/ProposalDetail.stories.tsx
+++ b/src/stories/ProposalDetail.stories.tsx
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
-		proposalId: 1,
 		title: 'Proposal Title',
 		applicant: 'Organization Name',
 		applicantId: '12-3456789',


### PR DESCRIPTION
This PR updates the UI for the ProposalDetail page and corresponding ProposalDetailPanel and ProposalGridList components, such that the proposal title is displayed first followed by organization name, and the data provider panel is removed. Furthermore, it adds default behavior to the proposal title such that if the proposal_name base field is empty,
it will use a truncated value from proposal_summary, and if both are empty a placeholder string is used.

Testing
- run `npm run start` in the front-end repository
- run `npm run start` in the service repository
- Create and upload three proposals with the following fields defined:
   ```csv
   proposal_name,proposal_summary,organization_name,proposal_submitter_email,organization_tax_id,organization_city,organization_state_province,organization_country
   ```
   ```csv
   proposal_summary,organization_name,proposal_submitter_email,organization_tax_id,organization_city,organization_state_province,organization_country
   ```
   ```csv
   organization_name,proposal_submitter_email,organization_tax_id,organization_city,organization_state_province,organization_country
   ```
- on the front-end in your browser, go to http://localhost:3000:proposals and click on one of the proposals
- verify the title and layout as accurate for each proposal

Closes #602 