### PR TITLE
Add Proposals table to Organization Detail Page

### DIFF
--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -7,6 +7,7 @@ import { Organization } from '@pdc/sdk';
 import {
 	Panel,
 	PanelActions,
+	PanelBody,
 	PanelHeader,
 	PanelTag,
 	PanelTitle,
@@ -20,13 +21,19 @@ import {
 	DropdownMenuText,
 	DropdownTrigger,
 } from './Dropdown';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
+import { ProposalListTable } from './ProposalListTable';
 
 interface OrganizationDetailPanelProps {
 	organization: Organization;
+	proposals: FrontEndProposal[];
+	proposalFields: Record<string, string>;
 }
 
 const OrganizationDetailPanel = ({
 	organization,
+	proposals,
+	proposalFields,
 }: OrganizationDetailPanelProps) => {
 	const { id, name, employerIdentificationNumber } = organization;
 	return (
@@ -70,6 +77,9 @@ const OrganizationDetailPanel = ({
 					</Dropdown>
 				</PanelActions>
 			</PanelHeader>
+			<PanelBody padded={false}>
+				<ProposalListTable fieldNames={proposalFields} proposals={proposals} />
+			</PanelBody>
 		</Panel>
 	);
 };

--- a/src/components/OrganizationListTable.tsx
+++ b/src/components/OrganizationListTable.tsx
@@ -32,7 +32,6 @@ const OrganizationListTableRow = ({
 
 const DEFAULT_ORGANIZATION_COLUMNS = ['Name', 'EIN'];
 
-
 interface OrganizationListTableProps {
 	organizations: OrganizationBundle;
 	columns?: string[];

--- a/src/components/OrganizationListTable.tsx
+++ b/src/components/OrganizationListTable.tsx
@@ -30,14 +30,17 @@ const OrganizationListTableRow = ({
 	);
 };
 
+const DEFAULT_ORGANIZATION_COLUMNS = ['Name', 'EIN'];
+
+
 interface OrganizationListTableProps {
 	organizations: OrganizationBundle;
-	columns: string[];
+	columns?: string[];
 }
 
 export const OrganizationListTable = ({
 	organizations,
-	columns,
+	columns = DEFAULT_ORGANIZATION_COLUMNS,
 }: OrganizationListTableProps) => (
 	<ListTable
 		items={organizations.entries}

--- a/src/components/OrganizationListTablePanel.tsx
+++ b/src/components/OrganizationListTablePanel.tsx
@@ -22,9 +22,7 @@ export const OrganizationListTablePanel = ({
 		<Panel>
 			<PanelBody padded={hasOrganizations}>
 				{hasOrganizations ? (
-					<OrganizationListTable
-						organizations={organizations}
-					/>
+					<OrganizationListTable organizations={organizations} />
 				) : (
 					<div className="quiet">{generateFallbackMessage()}</div>
 				)}

--- a/src/components/OrganizationListTablePanel.tsx
+++ b/src/components/OrganizationListTablePanel.tsx
@@ -8,8 +8,6 @@ interface OrganizationListTablePanelProps {
 	loading?: boolean;
 }
 
-const DEFAULT_COLUMNS = ['Name', 'EIN'];
-
 export const OrganizationListTablePanel = ({
 	organizations = undefined,
 	loading = false,
@@ -26,7 +24,6 @@ export const OrganizationListTablePanel = ({
 				{hasOrganizations ? (
 					<OrganizationListTable
 						organizations={organizations}
-						columns={DEFAULT_COLUMNS}
 					/>
 				) : (
 					<div className="quiet">{generateFallbackMessage()}</div>

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -42,16 +42,36 @@ const ProposalListTableRow = ({
 };
 
 interface ProposalListTableProps {
-	columns: string[];
 	fieldNames: Record<string, string>;
 	proposals: FrontEndProposal[];
 	wrap?: boolean;
+	columns?: string[];
 }
+
+const DEFAULT_PROPOSAL_COLUMNS = [
+	'organization_name',
+	'organization_tax_id',
+	'organization_city',
+	'organization_state_province',
+	'organization_country',
+	'organization_website',
+	'organization_mission_statement',
+	'organization_start_date',
+	'organization_operating_budget',
+	'proposal_name',
+	'proposal_summary',
+	'proposal_amount_requested',
+	'proposal_budget',
+	'proposal_fiscal_sponsor_name',
+	'proposal_start_date',
+	'proposal_end_date',
+	'proposal_location_of_work',
+];
 
 export const ProposalListTable = ({
 	fieldNames,
 	proposals,
-	columns,
+	columns = DEFAULT_PROPOSAL_COLUMNS,
 	wrap = false,
 }: ProposalListTableProps) => (
 	<ListTable

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -14,28 +14,6 @@ interface ProposalListTablePanelProps {
 	loading?: boolean;
 }
 
-// For now, we are hard-coding this list.
-// In the future, this will be user-configurable.
-const DEFAULT_COLUMNS = [
-	'organization_name',
-	'organization_tax_id',
-	'organization_city',
-	'organization_state_province',
-	'organization_country',
-	'organization_website',
-	'organization_mission_statement',
-	'organization_start_date',
-	'organization_operating_budget',
-	'proposal_name',
-	'proposal_summary',
-	'proposal_amount_requested',
-	'proposal_budget',
-	'proposal_fiscal_sponsor_name',
-	'proposal_start_date',
-	'proposal_end_date',
-	'proposal_location_of_work',
-];
-
 export const ProposalListTablePanel = ({
 	fieldNames,
 	proposals,
@@ -78,7 +56,6 @@ export const ProposalListTablePanel = ({
 					<ProposalListTable
 						fieldNames={fieldNames}
 						proposals={proposals}
-						columns={DEFAULT_COLUMNS}
 						wrap={wrap}
 					/>
 				) : (

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { Organization } from '@pdc/sdk';
@@ -9,9 +9,16 @@ import {
 	useOrganizations,
 	ORGANIZATIONS_DEFAULT_PAGE,
 	ORGANIZATIONS_DEFAULT_COUNT,
+	PROPOSALS_DEFAULT_PAGE,
+	PROPOSALS_DEFAULT_COUNT,
+	useBaseFields,
+	useProposalsByOrganizationId,
 } from '../pdc-api';
 import { OrganizationDetailPanel } from '../components/OrganizationDetailPanel';
 import { OrganizationListGridPanel } from '../components/OrganizationListGridPanel';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
+import { mapProposals } from '../map-proposals';
+import { mapFieldNames } from '../utils/baseFields';
 
 const OrganizationListGridPanelLoader = () => {
 	const { organizationId } = useParams();
@@ -39,6 +46,16 @@ const OrganizationDetailPanelLoader = () => {
 	const params = useParams();
 	const { provider, organizationId = 'missing' } = params;
 	const [organization] = useOrganization(organizationId);
+	const [fields] = useBaseFields();
+	const [proposals] = useProposalsByOrganizationId(
+		PROPOSALS_DEFAULT_PAGE,
+		PROPOSALS_DEFAULT_COUNT,
+		organizationId,
+	);
+	const emptyProposalArray: FrontEndProposal[] = [];
+	const [proposalState, setProposalState] = useState(emptyProposalArray);
+	const emptyRecord: Record<string, string> = {};
+	const [fieldsState, setFieldsState] = useState(emptyRecord);
 
 	useEffect(() => {
 		if (organization === null) {
@@ -46,10 +63,15 @@ const OrganizationDetailPanelLoader = () => {
 		} else {
 			document.title = `${organization.name} Organization Detail - Philanthropy Data Commons`;
 		}
+		if (fields && proposals) {
+			setFieldsState(mapFieldNames(fields));
+			setProposalState(mapProposals(fields, proposals.entries));
+		}
+
 		return () => {
 			document.title = 'Philanthropy Data Commons';
 		};
-	}, [organization]);
+	}, [fields, proposals, organization]);
 
 	if (organization === null) {
 		const dummyOrganization: Organization = {
@@ -61,7 +83,11 @@ const OrganizationDetailPanelLoader = () => {
 		return (
 			<>
 				<PanelGridItem key="detailPanel">
-					<OrganizationDetailPanel organization={dummyOrganization} />
+					<OrganizationDetailPanel
+						organization={dummyOrganization}
+						proposals={proposalState}
+						proposalFields={fieldsState}
+					/>
 				</PanelGridItem>
 				{provider && (
 					<PanelGridItem key="platformPanel">
@@ -80,7 +106,11 @@ const OrganizationDetailPanelLoader = () => {
 	return (
 		<>
 			<PanelGridItem key="detailPanel">
-				<OrganizationDetailPanel organization={organization} />
+				<OrganizationDetailPanel
+					organization={organization}
+					proposals={proposalState}
+					proposalFields={fieldsState}
+				/>
 			</PanelGridItem>
 			{provider && (
 				<PanelGridItem key="platformPanel">

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
-	ApiBaseField,
 	PROPOSALS_DEFAULT_COUNT,
 	PROPOSALS_DEFAULT_PAGE,
 	PROPOSALS_DEFAULT_QUERY,
@@ -12,9 +11,7 @@ import {
 import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
-
-const mapFieldNames = (fields: ApiBaseField[]) =>
-	Object.fromEntries(fields.map(({ label, shortCode }) => [shortCode, label]));
+import { mapFieldNames } from '../utils/baseFields';
 
 const ProposalListLoader = () => {
 	const navigate = useNavigate();

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -219,6 +219,20 @@ const useProposals = (page: string, count: string, query: string) =>
 		}),
 	);
 
+const useProposalsByOrganizationId = (
+	page: string,
+	count: string,
+	organizationId: string,
+) =>
+	usePdcApi<ApiProposals>(
+		'/proposals',
+		new URLSearchParams({
+			_page: page,
+			_count: count,
+			organization: organizationId,
+		}),
+	);
+
 interface PlatformProviderResponse {
 	createdAt: string;
 	externalId: string;
@@ -266,6 +280,7 @@ export {
 	usePresignedPostCallback,
 	useProposal,
 	useProposals,
+	useProposalsByOrganizationId,
 	useOrganization,
 	useOrganizations,
 	useProviderData,

--- a/src/utils/baseFields.ts
+++ b/src/utils/baseFields.ts
@@ -1,0 +1,12 @@
+import { ApiBaseField } from '../pdc-api';
+
+/**
+ * Iterates through a list of basefields, pairing labels with shortcodes
+ * Returns a Record<String,String> map of shortcodes to labels
+ * @param  {ApiBaseField[]} fields an array of ApiBaseFields
+ * @return {Record<string,string>} a map between basefield shortcodes and labels
+ */
+const mapFieldNames = (fields: ApiBaseField[]) =>
+	Object.fromEntries(fields.map(({ label, shortCode }) => [shortCode, label]));
+
+export { mapFieldNames };


### PR DESCRIPTION
This pull request adds a proposals table to the organization detail page. Currently it will load all proposals for any organization, but once organizations are linked to proposals another edition will be necessary to display related proposals.

Closes #612 

Testing:
- run pdc service
- populate service with at least 1 organization and 1 proposal
- run front-end
- navigate to 'organizations' on the front-end
- click an organization
- verify that the detail page you are redirected to has both the organization information and all proposals in the database displayed in a table below.