### PR TITLE
Improve navbar icons and order

### DIFF
--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -56,39 +56,6 @@ const AppNavbar = () => {
 				<li>
 					<Dropdown>
 						<DropdownTrigger type="navbar-item">
-							<CommandLineIconOutline className="closed-only" />
-							<CommandLineIconSolid className="open-only" />
-							Developers
-						</DropdownTrigger>
-						<DropdownMenu align="right">
-							<DropdownMenuLink to="https://api.philanthropydatacommons.org">
-								<div className="title">API Documentation</div>
-								<div className="description">
-									Read the Swagger spec to interact with the PDC via our API.
-								</div>
-							</DropdownMenuLink>
-							<DropdownMenuLink to="https://www.npmjs.com/package/@pdc/sdk">
-								<div className="title">TypeScript SDK</div>
-								<div className="description">
-									Develop with our TypeScript SDK using <code>@pdc/sdk</code>{' '}
-									from NPM.
-								</div>
-							</DropdownMenuLink>
-							{process.env.REACT_APP_SHOW_STORYBOOK === 'true' && (
-								<DropdownMenuLink to="/storybook" reloadDocument>
-									<div className="title">Storybook</div>
-									<div className="description">
-										View our UI component library. (Only relevant to PDC front
-										end developers.)
-									</div>
-								</DropdownMenuLink>
-							)}
-						</DropdownMenu>
-					</Dropdown>
-				</li>
-				<li>
-					<Dropdown>
-						<DropdownTrigger type="navbar-item">
 							<InformationCircleIconOutline className="closed-only" />
 							<InformationCircleIconSolid className="open-only" />
 							About
@@ -120,6 +87,39 @@ const AppNavbar = () => {
 									Keep up with recent changes and improvements to the PDC.
 								</div>
 							</DropdownMenuLink>
+						</DropdownMenu>
+					</Dropdown>
+				</li>
+				<li>
+					<Dropdown>
+						<DropdownTrigger type="navbar-item">
+							<CommandLineIconOutline className="closed-only" />
+							<CommandLineIconSolid className="open-only" />
+							Developers
+						</DropdownTrigger>
+						<DropdownMenu align="right">
+							<DropdownMenuLink to="https://api.philanthropydatacommons.org">
+								<div className="title">API Documentation</div>
+								<div className="description">
+									Read the Swagger spec to interact with the PDC via our API.
+								</div>
+							</DropdownMenuLink>
+							<DropdownMenuLink to="https://www.npmjs.com/package/@pdc/sdk">
+								<div className="title">TypeScript SDK</div>
+								<div className="description">
+									Develop with our TypeScript SDK using <code>@pdc/sdk</code>{' '}
+									from NPM.
+								</div>
+							</DropdownMenuLink>
+							{process.env.REACT_APP_SHOW_STORYBOOK === 'true' && (
+								<DropdownMenuLink to="/storybook" reloadDocument>
+									<div className="title">Storybook</div>
+									<div className="description">
+										View our UI component library. (Only relevant to PDC front
+										end developers.)
+									</div>
+								</DropdownMenuLink>
+							)}
 						</DropdownMenu>
 					</Dropdown>
 				</li>

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useOidc } from '@axa-fr/react-oidc';
-import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import {
-	CommandLineIcon,
-	SquaresPlusIcon,
-	TableCellsIcon,
+	CommandLineIcon as CommandLineIconOutline,
+	InformationCircleIcon as InformationCircleIconOutline,
+	SquaresPlusIcon as SquaresPlusIconOutline,
+	TableCellsIcon as TableCellsIconOutline,
+} from '@heroicons/react/24/outline';
+import {
+	CommandLineIcon as CommandLineIconSolid,
+	InformationCircleIcon as InformationCircleIconSolid,
+	SquaresPlusIcon as SquaresPlusIconSolid,
+	TableCellsIcon as TableCellsIconSolid,
 } from '@heroicons/react/24/solid';
 import { User } from './User';
 import {
@@ -23,22 +29,35 @@ const AppNavbar = () => {
 			<ul>
 				<li>
 					<NavLink to="/proposals" className="App-navbar__item">
-						<TableCellsIcon />
-						Dashboard
+						{({ isActive }) => (
+							<>
+								{isActive ? <TableCellsIconSolid /> : <TableCellsIconOutline />}
+								Dashboard
+							</>
+						)}
 					</NavLink>
 				</li>
 				{isAuthenticated && (
 					<li>
 						<NavLink to="/add-data" className="App-navbar__item">
-							<SquaresPlusIcon />
-							Add Data
+							{({ isActive }) => (
+								<>
+									{isActive ? (
+										<SquaresPlusIconSolid />
+									) : (
+										<SquaresPlusIconOutline />
+									)}
+									Add Data
+								</>
+							)}
 						</NavLink>
 					</li>
 				)}
 				<li>
 					<Dropdown>
 						<DropdownTrigger type="navbar-item">
-							<CommandLineIcon />
+							<CommandLineIconOutline className="closed-only" />
+							<CommandLineIconSolid className="open-only" />
 							Developers
 						</DropdownTrigger>
 						<DropdownMenu align="right">
@@ -70,7 +89,8 @@ const AppNavbar = () => {
 				<li>
 					<Dropdown>
 						<DropdownTrigger type="navbar-item">
-							<InformationCircleIcon />
+							<InformationCircleIconOutline className="closed-only" />
+							<InformationCircleIconSolid className="open-only" />
 							About
 						</DropdownTrigger>
 						<DropdownMenu align="right">

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -127,3 +127,13 @@
 	height: var(--dropdown--menu-item--icon-size);
 	width: var(--dropdown--menu-item--icon-size);
 }
+
+.dropdown[open] .closed-only,
+.dropdown:not([open]) .open-only {
+	display: none;
+}
+
+.dropdown[open] .open-only,
+.dropdown:not([open]) .closed-only {
+	display: block;
+}

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useOidc, useOidcUser, OidcUserStatus } from '@axa-fr/react-oidc';
-import { UserIcon } from '@heroicons/react/24/solid';
+import { UserIcon as UserIconOutline } from '@heroicons/react/24/outline';
+import { UserIcon as UserIconSolid } from '@heroicons/react/24/solid';
 import { getLogger } from '../logger';
 
 const logger = getLogger('<User>');
@@ -13,7 +14,7 @@ const User = () => {
 		case OidcUserStatus.Loading:
 			return (
 				<div className="App-navbar__item App-navbar__item--loading">
-					<UserIcon />
+					<UserIconOutline />
 					Loading…
 				</div>
 			);
@@ -26,21 +27,21 @@ const User = () => {
 					}}
 					type="button"
 				>
-					<UserIcon />
+					<UserIconOutline />
 					Log in
 				</button>
 			);
 		case OidcUserStatus.LoadingError:
 			return (
 				<div className="App-navbar__item App-navbar__item--error">
-					<UserIcon />
+					<UserIconOutline />
 					User loading failed
 				</div>
 			);
 		default:
 			return (
 				<div className="App-navbar__item">
-					<UserIcon />
+					<UserIconSolid />
 					{oidcUser.name}
 				</div>
 			);


### PR DESCRIPTION
This PR changes our navbar icons to be outlines when inactive and solid when active. It also moves the Developer menu to "last" (farthest right) on the navbar, except that the user menu remains the _farthest_ right (as per standard design).

**Before:** Logged out, on the Landing page:
![1-before-loggedout](https://github.com/PhilanthropyDataCommons/front-end/assets/4731/33e5ef6e-0059-4bdd-ab50-1648b6771da0)

**After:** Logged out, on the Landing page:
![2-after-logged-out](https://github.com/PhilanthropyDataCommons/front-end/assets/4731/ae112a07-d2c5-4f80-9bc6-aa64d6bd4816)

**Before:** Logged in, on the Dashboard page:
![1-before](https://github.com/PhilanthropyDataCommons/front-end/assets/4731/8df45379-d623-453f-a3f4-2fccf9a7f2c5)

**After:** Logged in, on the Dashboard page:
![2-after](https://github.com/PhilanthropyDataCommons/front-end/assets/4731/097bb5db-fb99-4a49-aad5-d46629a55bba)

**Testing:**

Navbar icons should be outlined by default. They should turn solid when:

- **Dashboard** and **Add Data**: solid when you are actually on those page
  - ✋ These will also be blue
- **About** dropdown, **Developers** dropdown: solid when the menu is open
- **User** icon: solid when you are logged in

Closes #606
Closes #660