### PR TITLE
😈 Configure Dependabot to ignore ESLint major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - 'version-update:semver-major'
+      - dependency-name: '*eslint*'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       storybook:
         dependency-type: 'development'


### PR DESCRIPTION
ESLint 18 has dependencies that are evidently incompatible with our current dev framework, Create React App. Until that’s replaced (#498), let’s disable Dependabot updating ESLint past 17.x.

As a Dependabot configuration change, there's not really a way to test this besides merging it in and observing Dependabot behavior. But eyes on it (and verifying the strategy) are appreciated!

Note that I've also created issue #665 to capture _removing_ this ignore rule once #498 is resolved and ESLint v18 compatibility ensured.

Closes #664