### PR TITLE
Add proposal side panel to organizations page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,15 @@ const router = createBrowserRouter([
 			{ path: '/', Component: Landing },
 			{ path: '/add-data', Component: AddData },
 			{
-				path: '/organizations/:organizationId/provider?/:provider?',
+				path: '/organizations/:organizationId',
+				Component: OrganizationDetail,
+			},
+			{
+				path: '/organizations/:organizationId/provider/:provider',
+				Component: OrganizationDetail,
+			},
+			{
+				path: '/organizations/:organizationId/proposals/:proposalId',
 				Component: OrganizationDetail,
 			},
 			{

--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -22,18 +22,23 @@ import {
 	DropdownTrigger,
 } from './Dropdown';
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
-import { ProposalListTable } from './ProposalListTable';
+import {
+	ProposalDetailDestinations,
+	ProposalListTable,
+} from './ProposalListTable';
 
 interface OrganizationDetailPanelProps {
 	organization: Organization;
 	proposals: FrontEndProposal[];
 	proposalFields: Record<string, string>;
+	activeProposalId?: string | undefined;
 }
 
 const OrganizationDetailPanel = ({
 	organization,
 	proposals,
 	proposalFields,
+	activeProposalId = undefined,
 }: OrganizationDetailPanelProps) => {
 	const { id, name, employerIdentificationNumber } = organization;
 	return (
@@ -77,8 +82,16 @@ const OrganizationDetailPanel = ({
 					</Dropdown>
 				</PanelActions>
 			</PanelHeader>
-			<PanelBody padded={false}>
-				<ProposalListTable fieldNames={proposalFields} proposals={proposals} />
+			<PanelBody>
+				<ProposalListTable
+					fieldNames={proposalFields}
+					proposals={proposals}
+					rowClickDestination={
+						ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
+					}
+					organizationId={id}
+					activeProposalId={activeProposalId}
+				/>
 			</PanelBody>
 		</Panel>
 	);

--- a/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
@@ -27,7 +27,12 @@ const OrganizationProposalLoader = ({
 	if (baseFields === null || proposal === null) {
 		return (
 			<PanelGridItem key="detailPanel">
-				<OrganizationProposalPanel version={0} values={[]} onClose={onClose} />
+				<OrganizationProposalPanel
+					proposalId={proposalId}
+					version={0}
+					values={[]}
+					onClose={onClose}
+				/>
 			</PanelGridItem>
 		);
 	}
@@ -39,6 +44,7 @@ const OrganizationProposalLoader = ({
 	return (
 		<PanelGridItem key="detailPanel">
 			<OrganizationProposalPanel
+				proposalId={proposalId}
 				version={version}
 				values={values}
 				onClose={onClose}

--- a/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { Organization } from '@pdc/sdk';
+import { useBaseFields, useProposal } from '../../pdc-api';
+import { PanelGridItem } from '../PanelGrid';
+import { OrganizationProposalPanel } from './OrganizationProposalPanel';
+import { mapProposalBaseFields, getTitle } from '../../utils/proposalFields';
+
+interface OrganizationProposalLoaderProps {
+	organization: Organization;
+	proposalId: string;
+	onClose(): void;
+}
+const OrganizationProposalLoader = ({
+	organization,
+	proposalId,
+	onClose,
+}: OrganizationProposalLoaderProps) => {
+	const [baseFields] = useBaseFields();
+	const [proposal] = useProposal(proposalId);
+	useEffect(() => {
+		document.title = `${organization.name} Proposal Detail - Philanthropy Data Commons`;
+		return () => {
+			document.title = 'Philanthropy Data Commons';
+		};
+	}, [organization.name]);
+
+	if (baseFields === null || proposal === null) {
+		return (
+			<PanelGridItem key="detailPanel">
+				<OrganizationProposalPanel version={0} values={[]} onClose={onClose} />
+			</PanelGridItem>
+		);
+	}
+
+	const version = proposal.versions[0]?.version ?? 0;
+	const values = mapProposalBaseFields(baseFields, proposal);
+	const title = getTitle(baseFields, proposal);
+
+	return (
+		<PanelGridItem key="detailPanel">
+			<OrganizationProposalPanel
+				version={version}
+				values={values}
+				onClose={onClose}
+				title={title}
+			/>
+		</PanelGridItem>
+	);
+};
+
+export { OrganizationProposalLoader };

--- a/src/components/OrganizationProposal/OrganizationProposalPanel.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalPanel.tsx
@@ -1,9 +1,34 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowsPointingOutIcon } from '@heroicons/react/24/solid';
 import { ClosablePanel, PanelTitle } from '../Panel';
 import { ProposalTable } from '../ProposalTable';
+import { Button } from '../Button';
 
+interface OrganizationProposalPanelActionsProps {
+	proposalId: string;
+}
+
+const OrganizationProposalPanelActions = ({
+	proposalId,
+}: OrganizationProposalPanelActionsProps) => {
+	const navigate = useNavigate();
+	const handleClick = () => {
+		navigate(`/proposals/${proposalId}`);
+	};
+	return (
+		<Button
+			onClick={handleClick}
+			color="gray"
+			title="Expand proposal to full page"
+		>
+			<ArrowsPointingOutIcon className="icon" />
+		</Button>
+	);
+};
 
 interface OrganizationProposalPanelProps {
+	proposalId: string;
 	version: number;
 	values: {
 		shortCode: string;
@@ -16,6 +41,7 @@ interface OrganizationProposalPanelProps {
 }
 
 const OrganizationProposalPanel = ({
+	proposalId,
 	version,
 	values,
 	onClose,
@@ -25,6 +51,7 @@ const OrganizationProposalPanel = ({
 		title={<PanelTitle>{title}</PanelTitle>}
 		onClose={onClose}
 		padded={false}
+		actions={<OrganizationProposalPanelActions proposalId={proposalId} />}
 	>
 		<ProposalTable version={version} values={values} />
 	</ClosablePanel>

--- a/src/components/OrganizationProposal/OrganizationProposalPanel.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalPanel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ClosablePanel, PanelTitle } from '../Panel';
+import { ProposalTable } from '../ProposalTable';
+
+
+interface OrganizationProposalPanelProps {
+	version: number;
+	values: {
+		shortCode: string;
+		fieldName: string;
+		position: number;
+		value: string;
+	}[];
+	onClose(): void;
+	title?: string;
+}
+
+const OrganizationProposalPanel = ({
+	version,
+	values,
+	onClose,
+	title = 'Untitled Proposal',
+}: OrganizationProposalPanelProps) => (
+	<ClosablePanel
+		title={<PanelTitle>{title}</PanelTitle>}
+		onClose={onClose}
+		padded={false}
+	>
+		<ProposalTable version={version} values={values} />
+	</ClosablePanel>
+);
+
+export { OrganizationProposalPanel };

--- a/src/components/Panel/ClosablePanel.tsx
+++ b/src/components/Panel/ClosablePanel.tsx
@@ -15,6 +15,7 @@ interface ClosablePanelProps {
 	 * Controls whether the panel body has internal padding.
 	 */
 	padded?: boolean;
+	actions?: React.ReactNode;
 }
 
 const ClosablePanel = ({
@@ -22,11 +23,13 @@ const ClosablePanel = ({
 	onClose,
 	title,
 	padded = true,
+	actions = undefined,
 }: ClosablePanelProps) => (
 	<Panel>
 		<PanelHeader>
 			<PanelTitleWrapper>{title}</PanelTitleWrapper>
 			<PanelActions>
+				{actions}
 				<Button onClick={onClose} color="red" title="Close this panel">
 					<XMarkIcon className="icon" />
 				</Button>

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -73,8 +73,12 @@
 	cursor: pointer;
 }
 
-.table .clickable:hover {
+.table .clickable:not(.active):hover {
 	background-color: var(--color--gray--lighter);
+}
+
+.table .active {
+	background-color: var(--color--blue--lighter);
 }
 
 .table .has-actions .column-head-wrapper {

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -4,15 +4,17 @@ interface TableRowProps {
 	children: React.ReactNode;
 	className?: string;
 	onClick?: () => void;
+	active?: boolean;
 }
 
 export const TableRow = ({
 	children,
 	className = '',
 	onClick = undefined,
+	active = false,
 }: TableRowProps) => (
 	<tr
-		className={`${className} ${onClick ? 'clickable' : ''}`.trim()}
+		className={`${className} ${onClick ? 'clickable' : ''} ${active ? 'active' : ''}`.trim()}
 		onClick={onClick}
 	>
 		{children}

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -19,6 +19,7 @@ import { OrganizationListGridPanel } from '../components/OrganizationListGridPan
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { mapProposals } from '../map-proposals';
 import { mapFieldNames } from '../utils/baseFields';
+import { OrganizationProposalLoader } from '../components/OrganizationProposal/OrganizationProposalLoader';
 
 const OrganizationListGridPanelLoader = () => {
 	const { organizationId } = useParams();
@@ -44,7 +45,7 @@ const OrganizationListGridPanelLoader = () => {
 const OrganizationDetailPanelLoader = () => {
 	const navigate = useNavigate();
 	const params = useParams();
-	const { provider, organizationId = 'missing' } = params;
+	const { provider, organizationId = 'missing', proposalId } = params;
 	const [organization] = useOrganization(organizationId);
 	const [fields] = useBaseFields();
 	const [proposals] = useProposalsByOrganizationId(
@@ -110,6 +111,7 @@ const OrganizationDetailPanelLoader = () => {
 					organization={organization}
 					proposals={proposalState}
 					proposalFields={fieldsState}
+					activeProposalId={proposalId}
 				/>
 			</PanelGridItem>
 			{provider && (
@@ -122,6 +124,15 @@ const OrganizationDetailPanelLoader = () => {
 						}}
 					/>
 				</PanelGridItem>
+			)}
+			{proposalId && (
+				<OrganizationProposalLoader
+					proposalId={proposalId}
+					organization={organization}
+					onClose={() => {
+						navigate(`/organizations/${organizationId}`);
+					}}
+				/>
 			)}
 		</>
 	);

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -18,9 +18,12 @@ import { ProposalListGridPanel } from '../components/ProposalListGridPanel';
 import {
 	PROPOSAL_APPLICANT_NAME_CASCADE,
 	PROPOSAL_APPLICANT_NAME_FALLBACK,
-	PROPOSAL_NAME_CASCADE,
-	PROPOSAL_NAME_FALLBACK,
 } from '../utils/proposals';
+import {
+	mapProposalBaseFields,
+	getValueOfBaseField,
+	getTitle,
+} from '../utils/proposalFields';
 
 interface ProposalListGridLoaderProps {
 	baseFields: ApiBaseField[] | null;
@@ -51,38 +54,6 @@ const ProposalListGridLoader = ({
 	);
 };
 
-const getValueOfBaseField = (
-	baseFields: ApiBaseField[],
-	proposal: ApiProposal,
-	baseFieldShortCode: string,
-) => {
-	const field = baseFields.find(
-		({ shortCode }) => shortCode === baseFieldShortCode,
-	);
-	if (field === undefined) {
-		return undefined;
-	}
-	const fieldValue = proposal.versions[0]?.fieldValues.find(
-		({ applicationFormField }) => applicationFormField.baseFieldId === field.id,
-	);
-	return fieldValue?.value ?? undefined;
-};
-
-const mapBaseFields = (baseFields: ApiBaseField[], proposal: ApiProposal) =>
-	(proposal.versions[0]?.fieldValues ?? []).map(
-		({ applicationFormField, value }) => {
-			const baseField = baseFields.find(
-				({ id }) => id === applicationFormField.baseFieldId,
-			);
-			return {
-				shortCode: baseField?.shortCode ?? 'missing',
-				fieldName: baseField?.label ?? 'missing',
-				position: applicationFormField.position,
-				value,
-			};
-		},
-	);
-
 const getApplicant = (baseFields: ApiBaseField[], proposal: ApiProposal) => {
 	const applicantNameKey = PROPOSAL_APPLICANT_NAME_CASCADE.find((key) => {
 		const baseFieldValue = getValueOfBaseField(baseFields, proposal, key);
@@ -95,20 +66,6 @@ const getApplicant = (baseFields: ApiBaseField[], proposal: ApiProposal) => {
 		? getValueOfBaseField(baseFields, proposal, applicantNameKey) ??
 				PROPOSAL_APPLICANT_NAME_FALLBACK
 		: PROPOSAL_APPLICANT_NAME_FALLBACK;
-};
-
-const getTitle = (baseFields: ApiBaseField[], proposal: ApiProposal) => {
-	const titleKey = PROPOSAL_NAME_CASCADE.find((key) => {
-		const baseFieldValue = getValueOfBaseField(baseFields, proposal, key);
-		return (
-			typeof baseFieldValue !== 'undefined' && baseFieldValue.trim() !== ''
-		);
-	});
-
-	return titleKey
-		? getValueOfBaseField(baseFields, proposal, titleKey) ??
-				PROPOSAL_NAME_FALLBACK
-		: PROPOSAL_NAME_FALLBACK;
 };
 
 interface ProposalDetailPanelLoaderProps {
@@ -156,7 +113,7 @@ const ProposalDetailPanelLoader = ({
 		'organization_tax_id',
 	);
 	const version = proposal.versions[0]?.version ?? 0;
-	const values = mapBaseFields(baseFields, proposal);
+	const values = mapProposalBaseFields(baseFields, proposal);
 
 	return (
 		<PanelGridItem key="detailPanel">

--- a/src/utils/proposalFields.ts
+++ b/src/utils/proposalFields.ts
@@ -1,0 +1,53 @@
+import { ApiBaseField, ApiProposal } from '../pdc-api';
+import { PROPOSAL_NAME_CASCADE, PROPOSAL_NAME_FALLBACK } from './proposals';
+
+const mapProposalBaseFields = (
+	baseFields: ApiBaseField[],
+	proposal: ApiProposal,
+) =>
+	(proposal.versions[0]?.fieldValues ?? []).map(
+		({ applicationFormField, value }) => {
+			const baseField = baseFields.find(
+				({ id }) => id === applicationFormField.baseFieldId,
+			);
+			return {
+				shortCode: baseField?.shortCode ?? 'missing',
+				fieldName: baseField?.label ?? 'missing',
+				position: applicationFormField.position,
+				value,
+			};
+		},
+	);
+
+const getValueOfBaseField = (
+	baseFields: ApiBaseField[],
+	proposal: ApiProposal,
+	baseFieldShortCode: string,
+) => {
+	const field = baseFields.find(
+		({ shortCode }) => shortCode === baseFieldShortCode,
+	);
+	if (field === undefined) {
+		return undefined;
+	}
+	const fieldValue = proposal.versions[0]?.fieldValues.find(
+		({ applicationFormField }) => applicationFormField.baseFieldId === field.id,
+	);
+	return fieldValue?.value ?? undefined;
+};
+
+const getTitle = (baseFields: ApiBaseField[], proposal: ApiProposal) => {
+	const titleKey = PROPOSAL_NAME_CASCADE.find((key) => {
+		const baseFieldValue = getValueOfBaseField(baseFields, proposal, key);
+		return (
+			typeof baseFieldValue !== 'undefined' && baseFieldValue.trim() !== ''
+		);
+	});
+
+	return titleKey
+		? getValueOfBaseField(baseFields, proposal, titleKey) ??
+				PROPOSAL_NAME_FALLBACK
+		: PROPOSAL_NAME_FALLBACK;
+};
+
+export { mapProposalBaseFields, getValueOfBaseField, getTitle };


### PR DESCRIPTION
This PR adds a side panel to the organizations detail page that is opened via clicking on a proposal in the Organizations proposal table. On click of the expansion icon, the user will be redirected to the related proposals detail page.

Closes #613 
Testing:
1. Start PDC front-end
2. Populate the database with (at least) 1 organization, 1 proposal, and 1 OrganizationProposal relating the organization and proposal
3. Navigate to `/organizations/1`
4. Click on the related proposal in the Organization's proposal table
5. Verify that the side panel opens on click, closes on click of the X icon, and redirects to the proposal's detail page on click of the expand icon