### PR TITLE
Fail eslint on warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"storybook": "storybook dev -p 6006",
 		"test": "react-scripts test",
 		"lint:prettier": "prettier . --check",
-		"lint:eslint": "eslint ./src --ext .ts,.tsx,.js",
+		"lint:eslint": "eslint ./src --ext .ts,.tsx,.js --max-warnings=0",
 		"lint": "npm run lint:eslint && npm run lint:prettier",
 		"format": "prettier . --write",
 		"eject": "react-scripts eject"


### PR DESCRIPTION
This PR updates our lint command so that it will return an error code if there are any warnings.  Prior to this commit our CI would pass even if there were warnings (e.g. console.log statements)

Resolves #523 