### PR TITLE
Improve display of navbar dropdowns

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,7 +47,7 @@
 	align-items: flex-start;
 	gap: calc(var(--fixed-spacing--1x) / 2);
 
-	font-size: 0.875rem;
+	font-size: var(--font-size--sm);
 	color: var(--navbar-item--color);
 	background-color: var(--navbar-item--background-color);
 	text-transform: uppercase;

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -19,6 +19,7 @@ import {
 	DropdownTrigger,
 	DropdownMenu,
 	DropdownMenuLink,
+	DropdownMenuLinkDescription,
 } from './Dropdown';
 
 const AppNavbar = () => {
@@ -62,30 +63,32 @@ const AppNavbar = () => {
 						</DropdownTrigger>
 						<DropdownMenu align="right">
 							<DropdownMenuLink to="https://www.philanthropydatacommons.org">
-								<div className="title">About the PDC project</div>
-								<div className="description">
+								About the PDC project
+								<DropdownMenuLinkDescription>
 									Read about the history, vision, and governance body of the
 									PDC.
-								</div>
+								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 							{!isAuthenticated && (
 								<DropdownMenuLink to="mailto:jimmcgowan@opentechstrategies.com?subject=PDC%20account">
-									<div className="title">Need an account?</div>
-									<div className="description">
+									Need an account?
+									<DropdownMenuLinkDescription>
 										Full access is restricted. Email Jim McGowan to request an
 										account.
-									</div>
+									</DropdownMenuLinkDescription>
 								</DropdownMenuLink>
 							)}
 							<DropdownMenuLink to="mailto:info@philanthropydatacommons.org?subject=PDC">
-								<div className="title">Questions or feedback</div>
-								<div className="description">Send an email to the team.</div>
+								Questions or feedback
+								<DropdownMenuLinkDescription>
+									Send an email to the team.
+								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 							<DropdownMenuLink to="https://github.com/PhilanthropyDataCommons/front-end/blob/main/RECENT_CHANGES.md">
-								<div className="title">Recent improvements</div>
-								<div className="description">
+								Recent improvements
+								<DropdownMenuLinkDescription>
 									Keep up with recent changes and improvements to the PDC.
-								</div>
+								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 						</DropdownMenu>
 					</Dropdown>
@@ -99,25 +102,25 @@ const AppNavbar = () => {
 						</DropdownTrigger>
 						<DropdownMenu align="right">
 							<DropdownMenuLink to="https://api.philanthropydatacommons.org">
-								<div className="title">API Documentation</div>
-								<div className="description">
+								API Documentation
+								<DropdownMenuLinkDescription>
 									Read the Swagger spec to interact with the PDC via our API.
-								</div>
+								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 							<DropdownMenuLink to="https://www.npmjs.com/package/@pdc/sdk">
-								<div className="title">TypeScript SDK</div>
-								<div className="description">
+								TypeScript SDK
+								<DropdownMenuLinkDescription>
 									Develop with our TypeScript SDK using <code>@pdc/sdk</code>{' '}
 									from NPM.
-								</div>
+								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 							{process.env.REACT_APP_SHOW_STORYBOOK === 'true' && (
 								<DropdownMenuLink to="/storybook" reloadDocument>
-									<div className="title">Storybook</div>
-									<div className="description">
+									Storybook
+									<DropdownMenuLinkDescription>
 										View our UI component library. (Only relevant to PDC front
 										end developers.)
-									</div>
+									</DropdownMenuLinkDescription>
 								</DropdownMenuLink>
 							)}
 						</DropdownMenu>

--- a/src/components/BulkUploadList.css
+++ b/src/components/BulkUploadList.css
@@ -13,7 +13,7 @@
 	border-bottom: 1px solid var(--color--gray);
 	background-color: var(--color--gray--lighter);
 
-	font-size: 0.9rem;
+	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--medium);
 	text-transform: uppercase;
 }

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -47,9 +47,9 @@
 	width: var(--dropdown--menu--width);
 
 	background-color: white;
-	border-radius: 8px;
+	border-radius: var(--dropdown--menu--border-radius);
 	border: 1px solid var(--color--gray--medium);
-	overflow: hidden;
+	overflow: visible;
 
 	display: flex;
 	flex-direction: column;
@@ -67,8 +67,15 @@
 	border-bottom: 1px solid var(--color--gray--light);
 }
 
+.dropdown-menu > *:first-child {
+	border-top-left-radius: var(--dropdown--menu--border-radius);
+	border-top-right-radius: var(--dropdown--menu--border-radius);
+}
+
 .dropdown-menu > *:last-child {
 	border-bottom: none;
+	border-bottom-left-radius: var(--dropdown--menu--border-radius);
+	border-bottom-right-radius: var(--dropdown--menu--border-radius);
 }
 
 /* CSS `transition` doesn't work when disclosing `<details>` element contents,

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -101,7 +101,7 @@
 
 .dropdown-menu-link.has-icon {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	gap: var(--fixed-spacing--1x);
 }
 
@@ -110,13 +110,10 @@
 	gap: var(--fixed-spacing--2x);
 }
 
-.dropdown-menu-link .title {
-	text-transform: uppercase;
-	font-size: var(--font-size--sm);
-}
-
 .dropdown-menu-link .description {
+	display: block;
 	font-weight: normal;
+	font-size: var(--font-size--sm);
 }
 
 .dropdown-menu-link:hover {
@@ -124,6 +121,7 @@
 }
 
 .dropdown-menu-link > svg {
+	flex-shrink: 0;
 	height: var(--dropdown--menu-item--icon-size);
 	width: var(--dropdown--menu-item--icon-size);
 }

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -88,7 +88,7 @@
 }
 
 .dropdown-menu-text {
-	font-size: 0.85rem;
+	font-size: var(--font-size--sm);
 	padding: var(--dropdown--menu--spacing);
 }
 
@@ -112,7 +112,7 @@
 
 .dropdown-menu-link .title {
 	text-transform: uppercase;
-	font-size: 0.9rem;
+	font-size: var(--font-size--sm);
 }
 
 .dropdown-menu-link .description {

--- a/src/components/Dropdown/DropdownMenuLink.tsx
+++ b/src/components/Dropdown/DropdownMenuLink.tsx
@@ -44,7 +44,7 @@ export const DropdownMenuLink = ({
 			reloadDocument={reloadDocument}
 		>
 			{icon && alignIcon === 'left' && icon}
-			{children}
+			<div>{children}</div>
 			{icon && alignIcon === 'right' && icon}
 		</Link>
 	);

--- a/src/components/Dropdown/DropdownMenuLinkDescription.tsx
+++ b/src/components/Dropdown/DropdownMenuLinkDescription.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface DropdownMenuLinkDescriptionProps {
+	children: React.ReactNode;
+}
+
+/**
+ * A `<Link>` element inside a dropdown menu.
+ */
+export const DropdownMenuLinkDescription = ({
+	children,
+}: DropdownMenuLinkDescriptionProps) => (
+	<small className="description">{children}</small>
+);

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -3,6 +3,7 @@ import { DropdownTrigger } from './DropdownTrigger';
 import { DropdownMenu } from './DropdownMenu';
 import { DropdownMenuText } from './DropdownMenuText';
 import { DropdownMenuLink } from './DropdownMenuLink';
+import { DropdownMenuLinkDescription } from './DropdownMenuLinkDescription';
 
 export {
 	Dropdown,
@@ -10,4 +11,5 @@ export {
 	DropdownMenu,
 	DropdownMenuText,
 	DropdownMenuLink,
+	DropdownMenuLinkDescription,
 };

--- a/src/components/ListGrid.css
+++ b/src/components/ListGrid.css
@@ -41,7 +41,7 @@
 
 .list-grid-item--details {
 	color: var(--list-grid-item--details--color);
-	font-size: 0.9em;
+	font-size: var(--font-size--sm);
 
 	display: flex;
 	flex-direction: row;

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@
 	--color--red: #892929;
 
 	--font-size: 16px;
+	--font-size--sm: 0.95rem;
 	--line-height: 1.4;
 	--font-family--sans-serif: 'Source Sans Pro', -apple-system,
 		BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
@@ -129,7 +130,7 @@ dl > .dli > dd {
 }
 
 code {
-	font-size: 0.8em;
+	font-size: 0.85em; /* em, not rem, so it is relative to its context. */
 	font-family: var(--font-family--monospace);
 	background-color: var(--color--gray--light);
 	border-radius: 0.5ch;
@@ -152,7 +153,7 @@ code.short-code {
 .badge {
 	background-color: var(--badge--background-color);
 	color: var(--badge--color);
-	font-size: 0.8em;
+	font-size: var(--font-size--sm);
 	padding: 0 0.25em;
 	border-radius: 2px;
 }
@@ -171,7 +172,7 @@ code.short-code {
 }
 
 .label {
-	font-size: 0.9rem;
+	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--medium);
 	text-transform: uppercase;
 }

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -11,6 +11,7 @@ import {
 	DropdownMenu,
 	DropdownMenuText,
 	DropdownMenuLink,
+	DropdownMenuLinkDescription,
 } from '../components/Dropdown';
 
 const meta = {
@@ -119,36 +120,7 @@ export const WithIconInTrigger: Story = {
 	],
 };
 
-export const WithMenuTitle: Story = {
-	args: {
-		children: [
-			<DropdownTrigger>Toggle menu</DropdownTrigger>,
-			<DropdownMenu>
-				<DropdownMenuText key="title1">
-					Some optional explainer text for the menu items:
-				</DropdownMenuText>
-				<DropdownMenuLink to="/" key="item1">
-					Item 1
-				</DropdownMenuLink>
-				<DropdownMenuLink to="/" key="item2">
-					Item 2
-				</DropdownMenuLink>
-				<DropdownMenuLink to="/" key="item3">
-					Item 3
-				</DropdownMenuLink>
-			</DropdownMenu>,
-		],
-	},
-	decorators: [
-		(Story) => (
-			<div style={{ height: '250px' }}>
-				<Story />
-			</div>
-		),
-	],
-};
-
-export const WithMultipleMenuTitles: Story = {
+export const WithMenuText: Story = {
 	args: {
 		children: [
 			<DropdownTrigger>Toggle menu</DropdownTrigger>,
@@ -185,7 +157,66 @@ export const WithMultipleMenuTitles: Story = {
 	],
 };
 
+export const WithLinkDescriptions: Story = {
+	args: {
+		children: [
+			<DropdownTrigger>Toggle menu</DropdownTrigger>,
+			<DropdownMenu>
+				<DropdownMenuLink to="/" key="item1">
+					Item 1
+					<DropdownMenuLinkDescription>
+						This explains something about this link.
+					</DropdownMenuLinkDescription>
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item2">
+					Item 2
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item3">
+					Item 3
+				</DropdownMenuLink>
+			</DropdownMenu>,
+		],
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: '400px' }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
 export const WithMenuItemIcons: Story = {
+	args: {
+		children: [
+			<DropdownTrigger>Toggle menu</DropdownTrigger>,
+			<DropdownMenu>
+				<DropdownMenuLink
+					to="/"
+					icon={<ArrowRightStartOnRectangleIcon />}
+					key="item1"
+				>
+					Item 1
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item2">
+					Item 2
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item3">
+					Item 3
+				</DropdownMenuLink>
+			</DropdownMenu>,
+		],
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: '200px' }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const WithMenuItemIconsOnRight: Story = {
 	args: {
 		children: [
 			<DropdownTrigger>Toggle menu</DropdownTrigger>,
@@ -203,6 +234,43 @@ export const WithMenuItemIcons: Story = {
 				</DropdownMenuLink>
 				<DropdownMenuLink to="/" key="item3">
 					Item 3
+				</DropdownMenuLink>
+			</DropdownMenu>,
+		],
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: '200px' }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const WithMenuItemIconsAndDescriptions: Story = {
+	args: {
+		children: [
+			<DropdownTrigger>Toggle menu</DropdownTrigger>,
+			<DropdownMenu>
+				<DropdownMenuLink
+					to="/"
+					icon={<ArrowRightStartOnRectangleIcon />}
+					key="item1"
+				>
+					Item 1
+					<DropdownMenuLinkDescription>
+						This explains something about this link.
+					</DropdownMenuLinkDescription>
+				</DropdownMenuLink>
+				<DropdownMenuLink
+					to="/"
+					icon={<ArrowRightStartOnRectangleIcon />}
+					key="item2"
+				>
+					Item 2
+					<DropdownMenuLinkDescription>
+						This explains something about this link.
+					</DropdownMenuLinkDescription>
 				</DropdownMenuLink>
 			</DropdownMenu>,
 		],


### PR DESCRIPTION
This PR improves the look of our navbar dropdowns in preparation for the user menu dropdown (#618).

Before:
<img width="295" alt="dropdown-before" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/21ecf721-ea1a-4b23-ad5d-b4a1dd76c492">

After:
<img width="295" alt="dropdown-after" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/feeaaca1-90a1-4d7a-bd60-1d354de0e59a">

<details>
<summary>If you think that's a stylistic regression…</summary>

Maybe some of you will think "Ah, but, that's less attractive!" And you're not wrong, but, the new format looks better when interleaved with more traditional dropdown items (which we don't want to always force into the "small uppercase" format):

https://github.com/PhilanthropyDataCommons/front-end/assets/4731/7097f3dc-e41b-4ed1-95e1-9700e8c5ccef

</details>

Along for the ride come some text accessibility improvements and an improvement to the `:focus` outline when keyboard-navigating the menu.

**Testing:**

You can test this via the [deploy preview](https://deploy-preview-676--philanthropy-data-commons-viewer.netlify.app), since the affected menus are available while logged-out. You can also hit the [Storybook deployment](https://deploy-preview-676--philanthropy-data-commons-viewer.netlify.app/storybook/?path=/docs/stories-dropdown--docs) to see the updated Dropdown stories. Just make sure dropdowns are legible and not a regression from earlier forms.

Resolves #667