### PR TITLE
Limit navbar to only one open dropdown at a time

### DIFF
--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -55,7 +55,7 @@ const AppNavbar = () => {
 					</li>
 				)}
 				<li>
-					<Dropdown>
+					<Dropdown name="navbar-dropdown">
 						<DropdownTrigger type="navbar-item">
 							<InformationCircleIconOutline className="closed-only" />
 							<InformationCircleIconSolid className="open-only" />
@@ -94,7 +94,7 @@ const AppNavbar = () => {
 					</Dropdown>
 				</li>
 				<li>
-					<Dropdown>
+					<Dropdown name="navbar-dropdown">
 						<DropdownTrigger type="navbar-item">
 							<CommandLineIconOutline className="closed-only" />
 							<CommandLineIconSolid className="open-only" />

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -7,11 +7,18 @@ interface DropdownProps {
 	 * in that order.
 	 */
 	children: React.ReactNode;
+	/**
+	 * When multiple dropdowns have the same `name`,
+	 * only one of them can be open at a time (like an accordion).
+	 */
+	name?: string;
 }
 
 /**
  * Accessible, JavaScript-free dropdowns using the `<details>` element.
  */
-export const Dropdown = ({ children }: DropdownProps) => (
-	<details className="dropdown">{children}</details>
+export const Dropdown = ({ children, name = undefined }: DropdownProps) => (
+	<details className="dropdown" name={name}>
+		{children}
+	</details>
 );

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -283,3 +283,40 @@ export const WithMenuItemIconsAndDescriptions: Story = {
 		),
 	],
 };
+
+/**
+ * Only one of these can be open at once, because they use the same `name` property.
+ * This is tricky to see in action in the Storybook context, but:
+ *
+ * 1. Open the left-hand dropdown.
+ * 2. Tab through its items. (This may not work on macOS unless you have enabled *System Settings* → *Keyboard* → *Keyboard navigation*.)
+ * 3. After tab focus leaves the third item, it will be on the second dropdown trigger. (Invisibly, sorry.)
+ * 4. Hit space or return to activate the second dropdown.
+ * 5. Note that the first dropdown menu closes and the second opens.
+ */
+export const AccordionStyle: Story = {
+	args: {
+		name: 'whatever',
+		children: [
+			<DropdownTrigger>Toggle menu</DropdownTrigger>,
+			<DropdownMenu>
+				<DropdownMenuLink to="/" key="item1">
+					Item 1
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item2">
+					Item 2
+				</DropdownMenuLink>
+				<DropdownMenuLink to="/" key="item3">
+					Item 3
+				</DropdownMenuLink>
+			</DropdownMenu>,
+		],
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: '200px' }}>
+				<Story key="story1" /> <Story key="story2" />
+			</div>
+		),
+	],
+};


### PR DESCRIPTION
Previously, you could "trick" the navbar into having multiple dropdowns open at a once by keyboard-navigating from an open menu to an adjacent trigger. (See video in #679.)

Since our Dropdowns use the HTML `<details>` element behind the scenes, and that element supports a [`name` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#name) precisely for adding accordion-like "just one open item at a time" behavior, this PR adds our own `name` prop to the `Dropdown` component to support the same thing.

**Testing:**

Preface: Firefox doesn't yet support this attribute, so you'll need to test this in Safari or Chrome. Also, the only way to really trigger this "bug" (and thus the only way to confirm it's fixed) is if your browser/OS combo allow tabbing through links. For macOS, this is disabled by default. Enable it in _System Settings_ → _Keyboard_ → _Keyboard navigation_.

1. Go to the `main`/[production site](https://app.philanthropydatacommons.org/)
2. Open the About menu in the navbar
3. Use the Tab key to tab through the items until the Developers navbar item is highlighted
4. Hit space/return to open it
5. :x: Note that both menus are open
6. Switch to the [deploy preview](https://deploy-preview-680--philanthropy-data-commons-viewer.netlify.app/) and repeat the steps
7. ✅ Note that About menu closes when the Developers menu opens

Resolves #679