### PR TITLE
Distinguish orgs from proposals better

### DIFF
--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -3,15 +3,15 @@ import { NavLink } from 'react-router-dom';
 import { useOidc } from '@axa-fr/react-oidc';
 import {
 	CommandLineIcon as CommandLineIconOutline,
+	DocumentTextIcon as DocumentTextIconOutline,
 	InformationCircleIcon as InformationCircleIconOutline,
 	SquaresPlusIcon as SquaresPlusIconOutline,
-	TableCellsIcon as TableCellsIconOutline,
 } from '@heroicons/react/24/outline';
 import {
 	CommandLineIcon as CommandLineIconSolid,
+	DocumentTextIcon as DocumentTextIconSolid,
 	InformationCircleIcon as InformationCircleIconSolid,
 	SquaresPlusIcon as SquaresPlusIconSolid,
-	TableCellsIcon as TableCellsIconSolid,
 } from '@heroicons/react/24/solid';
 import { User } from './User';
 import {
@@ -32,8 +32,12 @@ const AppNavbar = () => {
 					<NavLink to="/proposals" className="App-navbar__item">
 						{({ isActive }) => (
 							<>
-								{isActive ? <TableCellsIconSolid /> : <TableCellsIconOutline />}
-								Dashboard
+								{isActive ? (
+									<DocumentTextIconSolid />
+								) : (
+									<DocumentTextIconOutline />
+								)}
+								Proposals
 							</>
 						)}
 					</NavLink>

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -28,35 +28,37 @@ const AppNavbar = () => {
 	return (
 		<nav className="App-navbar">
 			<ul>
-				<li>
-					<NavLink to="/proposals" className="App-navbar__item">
-						{({ isActive }) => (
-							<>
-								{isActive ? (
-									<DocumentTextIconSolid />
-								) : (
-									<DocumentTextIconOutline />
-								)}
-								Proposals
-							</>
-						)}
-					</NavLink>
-				</li>
 				{isAuthenticated && (
-					<li>
-						<NavLink to="/add-data" className="App-navbar__item">
-							{({ isActive }) => (
-								<>
-									{isActive ? (
-										<SquaresPlusIconSolid />
-									) : (
-										<SquaresPlusIconOutline />
-									)}
-									Add Data
-								</>
-							)}
-						</NavLink>
-					</li>
+					<>
+						<li>
+							<NavLink to="/proposals" className="App-navbar__item">
+								{({ isActive }) => (
+									<>
+										{isActive ? (
+											<DocumentTextIconSolid />
+										) : (
+											<DocumentTextIconOutline />
+										)}
+										Proposals
+									</>
+								)}
+							</NavLink>
+						</li>
+						<li>
+							<NavLink to="/add-data" className="App-navbar__item">
+								{({ isActive }) => (
+									<>
+										{isActive ? (
+											<SquaresPlusIconSolid />
+										) : (
+											<SquaresPlusIconOutline />
+										)}
+										Add Data
+									</>
+								)}
+							</NavLink>
+						</li>
+					</>
 				)}
 				<li>
 					<Dropdown name="navbar-dropdown">

--- a/src/components/NewBulkUploadPanel.tsx
+++ b/src/components/NewBulkUploadPanel.tsx
@@ -55,7 +55,7 @@ export const NewBulkUploadPanel = ({
 				</section>
 
 				<section id="base-fields">
-					<h1>Base fields</h1>
+					<h2>Base fields</h2>
 
 					<div className="instructions">
 						<p>

--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -83,15 +83,24 @@ const OrganizationDetailPanel = ({
 				</PanelActions>
 			</PanelHeader>
 			<PanelBody>
-				<ProposalListTable
-					fieldNames={proposalFields}
-					proposals={proposals}
-					rowClickDestination={
-						ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
-					}
-					organizationId={id}
-					activeProposalId={activeProposalId}
-				/>
+				<section id="organization-proposals">
+					<h2>Proposals</h2>
+					{proposals.length > 0 ? (
+						<ProposalListTable
+							fieldNames={proposalFields}
+							proposals={proposals}
+							rowClickDestination={
+								ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
+							}
+							organizationId={id}
+							activeProposalId={activeProposalId}
+						/>
+					) : (
+						<p className="quiet">
+							There are no proposals linked to this organization.
+						</p>
+					)}
+				</section>
 			</PanelBody>
 		</Panel>
 	);

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -25,9 +25,7 @@
 }
 
 .panel-title {
-	font-size: 1.5rem;
-	font-weight: var(--font-weight--normal);
-	margin-bottom: 0.25em;
+	margin-bottom: 0.5em;
 
 	/* Limit display to two lines of text. */
 	-webkit-box-orient: vertical;

--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -73,6 +73,14 @@ interface ProposalListTableProps {
 }
 
 const DEFAULT_PROPOSAL_COLUMNS = [
+	'proposal_name',
+	'proposal_summary',
+	'proposal_amount_requested',
+	'proposal_budget',
+	'proposal_fiscal_sponsor_name',
+	'proposal_start_date',
+	'proposal_end_date',
+	'proposal_location_of_work',
 	'organization_name',
 	'organization_tax_id',
 	'organization_city',
@@ -82,14 +90,6 @@ const DEFAULT_PROPOSAL_COLUMNS = [
 	'organization_mission_statement',
 	'organization_start_date',
 	'organization_operating_budget',
-	'proposal_name',
-	'proposal_summary',
-	'proposal_amount_requested',
-	'proposal_budget',
-	'proposal_fiscal_sponsor_name',
-	'proposal_start_date',
-	'proposal_end_date',
-	'proposal_location_of_work',
 ];
 
 const ProposalListTable = ({

--- a/src/index.css
+++ b/src/index.css
@@ -86,10 +86,44 @@ h3,
 h4,
 h5,
 h6 {
-	margin: 0;
+	margin: 1rem 0;
 	padding: 0;
 	font-weight: var(--font-weight--normal);
 	line-height: 1.2;
+
+	&:first-child {
+		margin-block-start: 0;
+	}
+
+	&:last-child {
+		margin-block-end: 0;
+	}
+}
+
+h1 {
+	font-size: 1.75rem;
+}
+
+h2 {
+	font-size: 1.5rem;
+}
+
+h3 {
+	font-size: 1.3rem;
+}
+
+h4 {
+	font-size: 1.15rem;
+}
+
+h5 {
+	font-weight: var(--font-weight--medium);
+	font-size: 1rem;
+}
+
+h6 {
+	font-size: 0.95rem;
+	font-weight: var(--font-weight--medium);
 }
 
 /*
@@ -175,6 +209,7 @@ code.short-code {
 	font-size: var(--font-size--sm);
 	font-weight: var(--font-weight--medium);
 	text-transform: uppercase;
+	margin-block: 0;
 }
 
 a.no-visited {

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useOidc } from '@axa-fr/react-oidc';
-import { TableCellsIcon, UserIcon } from '@heroicons/react/24/solid';
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
+import { UserIcon } from '@heroicons/react/24/solid';
 import { getLogger } from '../logger';
 import { Panel, PanelBody } from '../components/Panel';
 import { Button } from '../components/Button';
@@ -32,8 +33,8 @@ const Landing = () => {
 						to="/proposals"
 						className="button button--color-blue button--inverted"
 					>
-						<TableCellsIcon className="icon" />
-						Go to the Dashboard
+						<DocumentTextIcon />
+						View proposals
 					</Link>
 				) : (
 					<Button


### PR DESCRIPTION
Now that we have org pages, and show proposals on those org pages, a couple of changes were necessary for clarity. This PR:

- Changes the default order of proposal table columns so that proposal-related columns come before org-related columns
- Adds a "Proposals" header to the proposals table on the org detail page
- Adds a fallback message instead of rendering an empty table on the org detail page, when an org has no proposals
- Renames Dashboard to Proposals (🎉) and only shows it to authenticated users
  - We still don't want to add an Organizations item to the navbar (#604) until users are actually going to start seeing orgs in the PDC, which means https://github.com/PhilanthropyDataCommons/service/issues/902
- Sets a standard set of heading font-sizes (and margins), and updates a few instances of prior heading use

**Testing:**

Compare the following pages to `main`/production. In the new version…

- The navbar should have a Proposals link instead of a Dashboard link.
- This link should only show up if you're logged in.
- `/proposals` should show proposal-related columns before org-related.
- An organization detail page (`/organizations/{id}`) for an org with **no** proposals should show a "There are no proposals linked to this organization." message.
- An organization detail page (`/organizations/{id}`) for an org **with** proposals should show the proposal table, and with proposal-related columns before org-related.

Closes #603
Closes #681
