### PR TITLE
Fix display issues with organizations tables

### DIFF
--- a/src/components/OrganizationListTablePanel.tsx
+++ b/src/components/OrganizationListTablePanel.tsx
@@ -20,7 +20,7 @@ export const OrganizationListTablePanel = ({
 
 	return (
 		<Panel>
-			<PanelBody padded={hasOrganizations}>
+			<PanelBody padded={!hasOrganizations}>
 				{hasOrganizations ? (
 					<OrganizationListTable organizations={organizations} />
 				) : (

--- a/src/components/Table/Table.css
+++ b/src/components/Table/Table.css
@@ -24,6 +24,14 @@
 	top: calc(-1 * var(--table--border-width));
 }
 
+.panel > .panel-body:first-child > .table:first-child thead.fixed {
+	top: 0;
+}
+
+.panel > .panel-body:first-child > .table:first-child thead.fixed th {
+	border-top: 0;
+}
+
 .table thead th {
 	border-top: var(--table--border-width) solid var(--color--gray--medium);
 	border-bottom: var(--table--border-width) solid var(--color--gray--medium);


### PR DESCRIPTION
Prior to this PR, the org table was incorrectly padded.

This PR fixes the padding, and resolves a display issue that is only noticeable once the padding was fixed.

**Testing:**
- In production, to go https://app.philanthropydatacommons.org/organizations
- ❌ Note the lack of padding around the "No data available" message
- On a local `main` with organizations data, go to `/organizations`
- ❌ Note the padding around the table
- Now, on this branch, repeat the above — well, however you can to trigger both states
- ✅ Note that the "No data available" message has padding, while the table doesn't

Closes #688 