### PR TITLE
Remove `proposal_submitter_email` bulk upload note

### DIFF
--- a/src/components/NewBulkUploadPanel.tsx
+++ b/src/components/NewBulkUploadPanel.tsx
@@ -39,11 +39,6 @@ export const NewBulkUploadPanel = ({
 								<strong>The first row must contain base field keys.</strong>{' '}
 								Each subsequent row will be imported as a new proposal.
 							</li>
-							<li>
-								<strong>
-									<code>proposal_submitter_email</code> field is required.
-								</strong>
-							</li>
 						</ul>
 
 						<h2 className="label">Optional</h2>


### PR DESCRIPTION
Tiny PR that removes some out of date instructions on our Bulk Upload page.

**Testing:** Just make sure the `proposal_submitter_email` requirement is gone from the bulk upload page. For extra credit, actually upload a CSV without a `proposal_submitter_email` column to make sure the instructions are still valid.

Closes #690 