### PR TITLE
Relocate page security to router

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { withOidcSecure } from '@axa-fr/react-oidc';
 import { Layout } from './Layout';
 import { AddData } from './pages/AddData';
 import { NotFound } from './pages/NotFound';
@@ -15,28 +16,28 @@ const router = createBrowserRouter([
 		Component: Layout,
 		children: [
 			{ path: '/', Component: Landing },
-			{ path: '/add-data', Component: AddData },
+			{ path: '/add-data', Component: withOidcSecure(AddData) },
 			{
 				path: '/organizations/:organizationId',
-				Component: OrganizationDetail,
+				Component: withOidcSecure(OrganizationDetail),
 			},
 			{
 				path: '/organizations/:organizationId/provider/:provider',
-				Component: OrganizationDetail,
+				Component: withOidcSecure(OrganizationDetail),
 			},
 			{
 				path: '/organizations/:organizationId/proposals/:proposalId',
-				Component: OrganizationDetail,
+				Component: withOidcSecure(OrganizationDetail),
 			},
 			{
 				path: '/organizations',
-				Component: OrganizationList,
+				Component: withOidcSecure(OrganizationList),
 			},
 			{
 				path: '/proposals/:proposalId',
-				Component: ProposalDetail,
+				Component: withOidcSecure(ProposalDetail),
 			},
-			{ path: '/proposals', Component: ProposalList },
+			{ path: '/proposals', Component: withOidcSecure(ProposalList) },
 			{ path: '*', Component: NotFound },
 		],
 	},

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { withOidcSecure } from '@axa-fr/react-oidc';
 import { DocumentPlusIcon } from '@heroicons/react/24/outline';
 import {
 	uploadUsingPresignedPost,
@@ -101,5 +100,4 @@ const AddDataLoader = () => {
 	);
 };
 
-const AddData = withOidcSecure(AddDataLoader);
-export { AddData };
+export { AddDataLoader as AddData };

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { withOidcSecure } from '@axa-fr/react-oidc';
 import { Organization } from '@pdc/sdk';
 import { DataPlatformProviderLoader } from '../components/DataPlatformProvider/DataPlatformProviderLoader';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
@@ -145,5 +144,4 @@ const OrganizationDetailLoader = () => (
 	</PanelGrid>
 );
 
-const OrganizationDetail = withOidcSecure(OrganizationDetailLoader);
-export { OrganizationDetail };
+export { OrganizationDetailLoader as OrganizationDetail };

--- a/src/pages/OrganizationList.tsx
+++ b/src/pages/OrganizationList.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { withOidcSecure } from '@axa-fr/react-oidc';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { OrganizationListTablePanel } from '../components/OrganizationListTablePanel';
 import {
@@ -37,5 +36,4 @@ const OrganizationListLoader = () => {
 	);
 };
 
-const OrganizationList = withOidcSecure(OrganizationListLoader);
-export { OrganizationList };
+export { OrganizationListLoader as OrganizationList };

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useParams } from 'react-router-dom';
 import {
 	ApiBaseField,
@@ -139,5 +138,4 @@ const ProposalDetailLoader = () => {
 	);
 };
 
-const ProposalDetail = withOidcSecure(ProposalDetailLoader);
-export { ProposalDetail };
+export { ProposalDetailLoader as ProposalDetail };

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { withOidcSecure } from '@axa-fr/react-oidc';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
 	PROPOSALS_DEFAULT_COUNT,
@@ -60,5 +59,4 @@ const ProposalListLoader = () => {
 	);
 };
 
-const ProposalList = withOidcSecure(ProposalListLoader);
-export { ProposalList };
+export { ProposalListLoader as ProposalList };


### PR DESCRIPTION
This PR moves securing pages from the components themselves to the app router. There should be no functional changes from the current system, it's just prerequisite work for the public pages — but a significant enough change to justify its own PR and review.

This is a syntax [explicitly demonstrated by our authentication library](https://github.com/AxaFrance/oidc-client/tree/main/packages/react-oidc#how-to-secure-a-component--hoc-method), which we did originally [consider but discarded](https://github.com/PhilanthropyDataCommons/front-end/pull/106#discussion_r1186521329) for reasons that I _think_ no longer apply. (We weren't using `<RouteProvider>` at the time.)

This will let us selectively secure routes that lead to the same page component that unprotected routes lead to. Specifically, we will [later, not in this PR] want public users to be able to access `/organizations/{id}` but not `/organizations/2/proposals/100` or `/organizations/2/providers/candid`. This will now be possible, even though both lead to the same page component. (Within that page component, we will still conditionally secure some child components, which we planned to do anyway.)

We're getting into the weeds outside my area of expertise, so please weigh in if this is a Bad Idea™!

**Testing:**

Test everything around authentication: accessing pages while logged out should force you to authenticate. After authenticating, you should be able to access all pages, etc. This should have zero behavioral/functional changes from the current system.

Resolves #693