### PR TITLE
Add public org views

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,16 +1,35 @@
+:root {
+	--app-banner--space-within: var(--fixed-spacing--halfx)
+		var(--fixed-spacing--1x);
+	--app-header--space-around: var(--fixed-spacing--2x) var(--fixed-spacing--2x)
+		var(--fixed-spacing--1x);
+	--app-main--space-around: var(--fixed-spacing--1x);
+}
+
 .App {
 	position: absolute;
 	inset: 0;
 
-	padding: var(--fixed-spacing--1x);
-
 	display: grid;
-	grid: min-content 1fr / auto;
-	gap: var(--fixed-spacing--1x);
+	grid-template:
+		'banner' min-content
+		'header' min-content
+		'main' 1fr
+		/ auto;
+}
+
+.App-banner {
+	grid-area: banner;
+	padding: var(--app-banner--space-within);
+	background-color: var(--color--gray);
+	font-weight: var(--font-weight--medium);
+	text-align: center;
 }
 
 .App-header {
-	padding: var(--fixed-spacing--1x);
+	grid-area: header;
+
+	margin: var(--app-header--space-around);
 
 	display: flex;
 	justify-content: space-between;
@@ -82,5 +101,7 @@
 }
 
 .App-main {
+	grid-area: main;
 	position: relative;
+	margin: var(--app-main--space-around);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const router = createBrowserRouter([
 			{ path: '/add-data', Component: withOidcSecure(AddData) },
 			{
 				path: '/organizations/:organizationId',
-				Component: withOidcSecure(OrganizationDetail),
+				Component: OrganizationDetail,
 			},
 			{
 				path: '/organizations/:organizationId/provider/:provider',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter([
 			},
 			{
 				path: '/organizations',
-				Component: withOidcSecure(OrganizationList),
+				Component: OrganizationList,
 			},
 			{
 				path: '/proposals/:proposalId',

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { AppBanner } from './components/AppBanner';
 import { AppHeader } from './components/AppHeader';
 import { AppMain } from './components/AppMain';
 
 const Layout = () => (
 	<div className="App">
+		<AppBanner />
 		<AppHeader />
 		<AppMain>
 			<Outlet />

--- a/src/components/AppBanner.tsx
+++ b/src/components/AppBanner.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useOidc } from '@axa-fr/react-oidc';
+import { Button } from './Button';
+import { getLogger } from '../logger';
+
+const logger = getLogger('<AppBanner>');
+
+const AppBanner = () => {
+	const location = useLocation();
+	const { isAuthenticated, login } = useOidc();
+
+	const isHomePage = location.pathname === '/';
+	const showBanner = !isAuthenticated && !isHomePage;
+
+	return showBanner ? (
+		<div className="App-banner">
+			You are viewing limited public data.{' '}
+			<Button
+				linkStyle
+				onClick={() => {
+					login(location.pathname).catch(logger.error);
+				}}
+			>
+				Log in to view more.
+			</Button>
+		</div>
+	) : null;
+};
+
+export { AppBanner };

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -51,7 +51,7 @@
 	background-color: var(--button--contrast-color--accent);
 }
 
-.button:not(:disabled):active {
+.button:not(:disabled, .button--link-style):active {
 	outline: 2px solid var(--button--primary-color--accent);
 }
 
@@ -122,4 +122,26 @@
 	position: absolute;
 	top: 3px;
 	right: 3px;
+}
+
+.button--link-style {
+	--button--primary-color: var(--color--blue);
+	--button--primary-color: var(--color--blue--dark);
+	--button--contrast-color: transparent;
+	--button--contrast-color--accent: transparent;
+
+	--button--border-color: transparent;
+	--button--border-radius: 0;
+
+	--button--font-size: 1em;
+	--button--height: auto;
+	--button--padding-y: 0;
+	--button--padding-x: 0;
+
+	text-decoration: underline;
+
+	&:hover,
+	&:focus {
+		text-decoration: none;
+	}
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,6 +29,10 @@ interface ButtonProps {
 	 * Sets the <button> type to "submit"
 	 */
 	submit?: boolean;
+	/**
+	 * Style the button like a text link
+	 */
+	linkStyle?: boolean;
 	title?: string;
 }
 
@@ -44,6 +48,7 @@ export const Button = ({
 	disabled = false,
 	onClick = () => true,
 	submit = false,
+	linkStyle = false,
 	title = undefined,
 }: ButtonProps) => {
 	const buttonClassNames = ['button', `button--color-${color}`];
@@ -58,6 +63,10 @@ export const Button = ({
 
 	if (notification) {
 		buttonClassNames.push('button--notification');
+	}
+
+	if (linkStyle) {
+		buttonClassNames.push('button--link-style');
 	}
 
 	return (

--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useOidc } from '@axa-fr/react-oidc';
 import {
 	ArrowRightStartOnRectangleIcon,
 	CircleStackIcon,
@@ -41,6 +42,11 @@ const OrganizationDetailPanel = ({
 	activeProposalId = undefined,
 }: OrganizationDetailPanelProps) => {
 	const { id, name, employerIdentificationNumber } = organization;
+	const { isAuthenticated } = useOidc();
+
+	const showDataProviderMenu = isAuthenticated;
+	const showProposalSection = isAuthenticated;
+
 	return (
 		<Panel>
 			<PanelHeader>
@@ -53,54 +59,58 @@ const OrganizationDetailPanel = ({
 					</PanelTitleTags>
 				</PanelTitleWrapper>
 				<PanelActions>
-					<Dropdown>
-						<DropdownTrigger>
-							<CircleStackIcon />
-							Data providers
-						</DropdownTrigger>
-						<DropdownMenu align="right">
-							<DropdownMenuText>
-								View applicant data from one of the data platform providers:
-							</DropdownMenuText>
-							<DropdownMenuLink
-								to={`/organizations/${id}/provider/candid`}
-								icon={<ArrowRightStartOnRectangleIcon />}
-								alignIcon="right"
-								key="candid"
-							>
-								Candid
-							</DropdownMenuLink>
-							<DropdownMenuLink
-								to={`/organizations/${id}/provider/charity-navigator`}
-								icon={<ArrowRightStartOnRectangleIcon />}
-								alignIcon="right"
-								key="charity-navigator"
-							>
-								Charity Navigator
-							</DropdownMenuLink>
-						</DropdownMenu>
-					</Dropdown>
+					{showDataProviderMenu && (
+						<Dropdown>
+							<DropdownTrigger>
+								<CircleStackIcon />
+								Data providers
+							</DropdownTrigger>
+							<DropdownMenu align="right">
+								<DropdownMenuText>
+									View applicant data from one of the data platform providers:
+								</DropdownMenuText>
+								<DropdownMenuLink
+									to={`/organizations/${id}/provider/candid`}
+									icon={<ArrowRightStartOnRectangleIcon />}
+									alignIcon="right"
+									key="candid"
+								>
+									Candid
+								</DropdownMenuLink>
+								<DropdownMenuLink
+									to={`/organizations/${id}/provider/charity-navigator`}
+									icon={<ArrowRightStartOnRectangleIcon />}
+									alignIcon="right"
+									key="charity-navigator"
+								>
+									Charity Navigator
+								</DropdownMenuLink>
+							</DropdownMenu>
+						</Dropdown>
+					)}
 				</PanelActions>
 			</PanelHeader>
 			<PanelBody>
-				<section id="organization-proposals">
-					<h2>Proposals</h2>
-					{proposals.length > 0 ? (
-						<ProposalListTable
-							fieldNames={proposalFields}
-							proposals={proposals}
-							rowClickDestination={
-								ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
-							}
-							organizationId={id}
-							activeProposalId={activeProposalId}
-						/>
-					) : (
-						<p className="quiet">
-							There are no proposals linked to this organization.
-						</p>
-					)}
-				</section>
+				{showProposalSection && (
+					<section id="organization-proposals">
+						<h2>Proposals</h2>
+						{proposals.length > 0 ? (
+							<ProposalListTable
+								fieldNames={proposalFields}
+								proposals={proposals}
+								rowClickDestination={
+									ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
+								}
+								organizationId={id}
+								activeProposalId={activeProposalId}
+							/>
+						) : (
+							<p className="quiet">
+								There are no proposals linked to this organization.
+							</p>
+						)}
+					</section>
+				)}
 			</PanelBody>
 		</Panel>
 	);

--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -22,30 +22,20 @@ import {
 	DropdownMenuText,
 	DropdownTrigger,
 } from './Dropdown';
-import { FrontEndProposal } from '../interfaces/FrontEndProposal';
-import {
-	ProposalDetailDestinations,
-	ProposalListTable,
-} from './ProposalListTable';
 
 interface OrganizationDetailPanelProps {
 	organization: Organization;
-	proposals: FrontEndProposal[];
-	proposalFields: Record<string, string>;
-	activeProposalId?: string | undefined;
+	children?: React.ReactNode;
 }
 
 const OrganizationDetailPanel = ({
 	organization,
-	proposals,
-	proposalFields,
-	activeProposalId = undefined,
+	children = undefined,
 }: OrganizationDetailPanelProps) => {
 	const { id, name, employerIdentificationNumber } = organization;
 	const { isAuthenticated } = useOidc();
 
 	const showDataProviderMenu = isAuthenticated;
-	const showProposalSection = isAuthenticated;
 
 	return (
 		<Panel>
@@ -90,28 +80,7 @@ const OrganizationDetailPanel = ({
 					)}
 				</PanelActions>
 			</PanelHeader>
-			<PanelBody>
-				{showProposalSection && (
-					<section id="organization-proposals">
-						<h2>Proposals</h2>
-						{proposals.length > 0 ? (
-							<ProposalListTable
-								fieldNames={proposalFields}
-								proposals={proposals}
-								rowClickDestination={
-									ProposalDetailDestinations.ORGANIZATION_PROPOSAL_PANEL
-								}
-								organizationId={id}
-								activeProposalId={activeProposalId}
-							/>
-						) : (
-							<p className="quiet">
-								There are no proposals linked to this organization.
-							</p>
-						)}
-					</section>
-				)}
-			</PanelBody>
+			<PanelBody>{children}</PanelBody>
 		</Panel>
 	);
 };

--- a/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect } from 'react';
 import { Organization } from '@pdc/sdk';
 import { useBaseFields, useProposal } from '../../pdc-api';
-import { OrganizationProposalPanel } from './OrganizationProposalPanel';
 import { mapProposalBaseFields, getTitle } from '../../utils/proposalFields';
+import { OrganizationProposalPanel } from './OrganizationProposalPanel';
 
 interface OrganizationProposalLoaderProps {
 	organization: Organization;
 	proposalId: string;
 	onClose(): void;
 }
+
 const OrganizationProposalLoader = ({
 	organization,
 	proposalId,

--- a/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
+++ b/src/components/OrganizationProposal/OrganizationProposalLoader.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { Organization } from '@pdc/sdk';
 import { useBaseFields, useProposal } from '../../pdc-api';
-import { PanelGridItem } from '../PanelGrid';
 import { OrganizationProposalPanel } from './OrganizationProposalPanel';
 import { mapProposalBaseFields, getTitle } from '../../utils/proposalFields';
 
@@ -26,14 +25,12 @@ const OrganizationProposalLoader = ({
 
 	if (baseFields === null || proposal === null) {
 		return (
-			<PanelGridItem key="detailPanel">
-				<OrganizationProposalPanel
-					proposalId={proposalId}
-					version={0}
-					values={[]}
-					onClose={onClose}
-				/>
-			</PanelGridItem>
+			<OrganizationProposalPanel
+				proposalId={proposalId}
+				version={0}
+				values={[]}
+				onClose={onClose}
+			/>
 		);
 	}
 
@@ -42,15 +39,13 @@ const OrganizationProposalLoader = ({
 	const title = getTitle(baseFields, proposal);
 
 	return (
-		<PanelGridItem key="detailPanel">
-			<OrganizationProposalPanel
-				proposalId={proposalId}
-				version={version}
-				values={values}
-				onClose={onClose}
-				title={title}
-			/>
-		</PanelGridItem>
+		<OrganizationProposalPanel
+			proposalId={proposalId}
+			version={version}
+			values={values}
+			onClose={onClose}
+			title={title}
+		/>
 	);
 };
 

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Organization } from '@pdc/sdk';
+import { FrontEndProposal } from '../interfaces/FrontEndProposal';
+import { mapProposals } from '../map-proposals';
+import { mapFieldNames } from '../utils/baseFields';
 import { DataPlatformProviderLoader } from '../components/DataPlatformProvider/DataPlatformProviderLoader';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import {
@@ -15,9 +18,6 @@ import {
 } from '../pdc-api';
 import { OrganizationDetailPanel } from '../components/OrganizationDetailPanel';
 import { OrganizationListGridPanel } from '../components/OrganizationListGridPanel';
-import { FrontEndProposal } from '../interfaces/FrontEndProposal';
-import { mapProposals } from '../map-proposals';
-import { mapFieldNames } from '../utils/baseFields';
 import { OrganizationProposalLoader } from '../components/OrganizationProposal/OrganizationProposalLoader';
 
 const OrganizationListGridPanelLoader = () => {
@@ -45,6 +45,12 @@ const OrganizationDetailPanelLoader = () => {
 	const navigate = useNavigate();
 	const params = useParams();
 	const { provider, organizationId = 'missing', proposalId } = params;
+
+	const emptyProposalArray: FrontEndProposal[] = [];
+	const [proposalState, setProposalState] = useState(emptyProposalArray);
+	const emptyRecord: Record<string, string> = {};
+	const [fieldsState, setFieldsState] = useState(emptyRecord);
+
 	const [organization] = useOrganization(organizationId);
 	const [fields] = useBaseFields();
 	const [proposals] = useProposalsByOrganizationId(
@@ -52,10 +58,6 @@ const OrganizationDetailPanelLoader = () => {
 		PROPOSALS_DEFAULT_COUNT,
 		organizationId,
 	);
-	const emptyProposalArray: FrontEndProposal[] = [];
-	const [proposalState, setProposalState] = useState(emptyProposalArray);
-	const emptyRecord: Record<string, string> = {};
-	const [fieldsState, setFieldsState] = useState(emptyRecord);
 
 	useEffect(() => {
 		if (organization === null) {
@@ -80,6 +82,7 @@ const OrganizationDetailPanelLoader = () => {
 			name: 'Loading...',
 			createdAt: new Date('2024-03-06'),
 		};
+
 		return (
 			<>
 				<PanelGridItem key="detailPanel">

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -125,13 +125,15 @@ const OrganizationDetailPanelLoader = () => {
 				</PanelGridItem>
 			)}
 			{proposalId && (
-				<OrganizationProposalLoader
-					proposalId={proposalId}
-					organization={organization}
-					onClose={() => {
-						navigate(`/organizations/${organizationId}`);
-					}}
-				/>
+				<PanelGridItem key="proposalPanel">
+					<OrganizationProposalLoader
+						proposalId={proposalId}
+						organization={organization}
+						onClose={() => {
+							navigate(`/organizations/${organizationId}`);
+						}}
+					/>
+				</PanelGridItem>
 			)}
 		</>
 	);

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useOidc } from '@axa-fr/react-oidc';
 import { Organization } from '@pdc/sdk';
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { mapProposals } from '../map-proposals';
@@ -42,6 +43,7 @@ const OrganizationListGridPanelLoader = () => {
 };
 
 const OrganizationDetailPanelLoader = () => {
+	const { isAuthenticated } = useOidc();
 	const navigate = useNavigate();
 	const params = useParams();
 	const { provider, organizationId = 'missing', proposalId } = params;
@@ -50,6 +52,9 @@ const OrganizationDetailPanelLoader = () => {
 	const [proposalState, setProposalState] = useState(emptyProposalArray);
 	const emptyRecord: Record<string, string> = {};
 	const [fieldsState, setFieldsState] = useState(emptyRecord);
+
+	const canSeeProviderPanel = isAuthenticated;
+	const canSeeProposalPanel = isAuthenticated;
 
 	const [organization] = useOrganization(organizationId);
 	const [fields] = useBaseFields();
@@ -75,6 +80,9 @@ const OrganizationDetailPanelLoader = () => {
 		};
 	}, [fields, proposals, organization]);
 
+	const showProviderPanel = provider && canSeeProviderPanel;
+	const showProposalPanel = proposalId && canSeeProposalPanel;
+
 	if (organization === null) {
 		const dummyOrganization: Organization = {
 			id: 0,
@@ -92,7 +100,7 @@ const OrganizationDetailPanelLoader = () => {
 						proposalFields={fieldsState}
 					/>
 				</PanelGridItem>
-				{provider && (
+				{showProviderPanel && (
 					<PanelGridItem key="platformPanel">
 						<DataPlatformProviderLoader
 							externalId={undefined}
@@ -106,6 +114,7 @@ const OrganizationDetailPanelLoader = () => {
 			</>
 		);
 	}
+
 	return (
 		<>
 			<PanelGridItem key="detailPanel">
@@ -116,7 +125,7 @@ const OrganizationDetailPanelLoader = () => {
 					activeProposalId={proposalId}
 				/>
 			</PanelGridItem>
-			{provider && (
+			{showProviderPanel && (
 				<PanelGridItem key="platformPanel">
 					<DataPlatformProviderLoader
 						provider={provider}
@@ -127,7 +136,7 @@ const OrganizationDetailPanelLoader = () => {
 					/>
 				</PanelGridItem>
 			)}
-			{proposalId && (
+			{showProposalPanel && (
 				<PanelGridItem key="proposalPanel">
 					<OrganizationProposalLoader
 						proposalId={proposalId}

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -96,6 +96,13 @@ export const IconOnly: Story = {
 	},
 };
 
+export const TextLinkStyle: Story = {
+	args: {
+		children: 'Link-Style Button',
+		linkStyle: true,
+	},
+};
+
 export const Disabled: Story = {
 	args: {
 		children: 'Button',


### PR DESCRIPTION
This PR adds publicly-accessible organization views (list and detail pages). It customizes the detail pages so that parts of the page that public visitors shouldn't see or use — data provider buttons/panels, proposal table/panels — are hidden. It also adds a banner atop the site that alerts public visitors that they may only be seeing a subset of the available data. This banner doesn't appear on the home page, just internal pages.

There are also a couple of minor clean-up commits to related code that are minor (and related) enough that I'd like to include them.

**Testing:**
1. On `main`/production, try to access `/organizations` or an organization detail page while logged out.
2. ❌ Note that you are redirected to the login form.
3. On this branch, do the same.
4. ✅ Note that despite not being logged-in, you are able to view the pages. 🎉
5. Verify that the public banner only appears for logged-out users on those pages (and not the home page).
6. For sanity, verify that you are still unable to access `/proposals`, the proposal detail pages, the Add Data page, and the two organization detail sub-pages (`/organizations/{id}/providers/{provider}` and `/organizations/{id}/proposals/{proposalId}`) while logged-out.

Resolves #571 
Resolves #566 
Resolves #560 