### PR TITLE
Add user logout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,8 +84,9 @@
 	--navbar-item--color: var(--color--blue);
 }
 
-.App-navbar__item:where(a, button, summary):is(:hover, :focus) {
+.App-navbar__item:where(a, button, summary):is(:hover, :focus-visible) {
 	--navbar-item--background-color: #0001;
+	--outline: none;
 }
 
 .App-navbar__item svg {

--- a/src/App.css
+++ b/src/App.css
@@ -101,6 +101,10 @@
 	color: var(--color--red);
 }
 
+.App-navbar .logout {
+	color: var(--color--red);
+}
+
 .App-main {
 	grid-area: main;
 	position: relative;

--- a/src/components/BulkUploaderFilePicker.css
+++ b/src/components/BulkUploaderFilePicker.css
@@ -54,8 +54,8 @@
 	pointer-events: none;
 }
 
-.file-picker button:focus {
-	outline: 2px solid blue;
+.file-picker button:focus-visible {
+	outline: var(--outline);
 }
 
 .file-picker input[type='file'] {

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -47,12 +47,8 @@
 	color: var(--button--primary-color);
 }
 
-.button:not(:disabled):is(:hover, :focus, :active) {
+.button:not(:disabled):is(:hover, :focus-visible, :active) {
 	background-color: var(--button--contrast-color--accent);
-}
-
-.button:not(:disabled, .button--link-style):active {
-	outline: 2px solid var(--button--primary-color--accent);
 }
 
 .button:disabled {
@@ -100,12 +96,8 @@
 	color: var(--button--contrast-color);
 }
 
-.button--inverted:not(:disabled):is(:hover, :focus, :active) {
+.button--inverted:not(:disabled):is(:hover, :focus-visible, :active) {
 	background-color: var(--button--primary-color--accent);
-}
-
-.button--inverted:not(:disabled):active {
-	outline: 2px solid var(--button--primary-color--accent);
 }
 
 .button--bordered {
@@ -153,7 +145,7 @@
 	text-decoration: underline;
 
 	&:hover,
-	&:focus {
+	&:focus-visible {
 		text-decoration: none;
 	}
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import './Button.css';
 
-interface ButtonProps {
-	/**
-	 * Contents of a `<Button>` can be a mix of strings and JSX elements,
-	 * and will be flex-aligned.
-	 */
-	children: React.ReactNode;
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	color?: 'gray' | 'blue' | 'red';
 	/**
 	 * Makes the button dark with light text.
@@ -24,11 +19,6 @@ interface ButtonProps {
 	 * Make the button occupy maximum available horizontal space.
 	 */
 	block?: boolean;
-	disabled?: boolean;
-	/**
-	 * Optional click handler
-	 */
-	onClick?: () => void;
 	/**
 	 * Sets the <button> type to "submit"
 	 */
@@ -37,24 +27,25 @@ interface ButtonProps {
 	 * Style the button like a text link
 	 */
 	linkStyle?: boolean;
-	title?: string;
+	className?: string;
 }
 
 /**
  * Primary UI component for user interaction.
+ *
+ * Extends the native `<button>` element, so all its props are available here.
  */
 export const Button = ({
-	children,
+	children = null,
 	color = 'gray',
 	inverted = false,
 	bordered = true,
 	notification = false,
 	block = false,
-	disabled = false,
-	onClick = () => true,
 	submit = false,
 	linkStyle = false,
-	title = undefined,
+	className = undefined,
+	...props
 }: ButtonProps) => {
 	const buttonClassNames = ['button', `button--color-${color}`];
 
@@ -78,13 +69,18 @@ export const Button = ({
 		buttonClassNames.push('button--link-style');
 	}
 
+	if (className !== undefined) {
+		buttonClassNames.push(className);
+	}
+
 	return (
 		<button
 			type={submit ? 'submit' : 'button'}
-			className={buttonClassNames.join(' ')}
-			disabled={disabled}
-			onClick={onClick}
-			title={title}
+			className={buttonClassNames.join(' ').trim()}
+			// We're extending a native element.
+			// This is precisely where prop-spreading is kosher.
+			// eslint-disable-next-line react/jsx-props-no-spreading
+			{...props}
 		>
 			{children}
 		</button>

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -1,7 +1,8 @@
 :root {
 	--dropdown--menu--border-radius: 8px;
 	--dropdown--menu--spacing: var(--accessible-spacing--1x);
-	--dropdown--menu--width: 30ch;
+	--dropdown--menu--min-width: 20ch;
+	--dropdown--menu--max-width: 30ch;
 	--dropdown--menu-item--icon-size: 1.5em;
 }
 
@@ -44,7 +45,9 @@
 .dropdown-menu {
 	position: absolute;
 	z-index: 100;
-	width: var(--dropdown--menu--width);
+	inline-size: max-content;
+	min-inline-size: var(--dropdown--menu--min-width);
+	max-inline-size: var(--dropdown--menu--max-width);
 
 	background-color: white;
 	border-radius: var(--dropdown--menu--border-radius);

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -99,35 +99,44 @@
 	padding: var(--dropdown--menu--spacing);
 }
 
-.dropdown-menu-link {
+.dropdown-menu-item:where(button) {
+	all: unset;
+
+	&:focus-visible {
+		outline: var(--outline);
+	}
+}
+
+.dropdown-menu-item {
 	color: inherit;
 	font-weight: var(--font-weight--medium);
 	text-decoration: none;
 	padding: var(--dropdown--menu--spacing);
+	cursor: pointer;
 }
 
-.dropdown-menu-link.has-icon {
+.dropdown-menu-item.has-icon {
 	display: flex;
 	align-items: flex-start;
 	gap: var(--fixed-spacing--1x);
 }
 
-.dropdown-menu-link.has-icon.align-icon--right {
+.dropdown-menu-item.has-icon.align-icon--right {
 	justify-content: space-between;
 	gap: var(--fixed-spacing--2x);
 }
 
-.dropdown-menu-link .description {
+.dropdown-menu-item .description {
 	display: block;
 	font-weight: normal;
 	font-size: var(--font-size--sm);
 }
 
-.dropdown-menu-link:hover {
+.dropdown-menu-item:hover {
 	background-color: var(--color--gray--lighter);
 }
 
-.dropdown-menu-link > svg {
+.dropdown-menu-item > svg {
 	flex-shrink: 0;
 	height: var(--dropdown--menu-item--icon-size);
 	width: var(--dropdown--menu-item--icon-size);

--- a/src/components/Dropdown/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton.tsx
@@ -1,16 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface DropdownMenuLinkProps {
-	/**
-	 * Destination path or URL.
-	 */
-	to: string;
+interface DropdownMenuButtonProps {
 	children: React.ReactNode;
-	/**
-	 * Skip client-side routing and let the browser load the URL like a normal `<a href>`.
-	 */
-	reloadDocument?: boolean;
 	/**
 	 * Optional Heroicon element, to prepend (left) or append (right) to menu link.
 	 */
@@ -20,34 +11,37 @@ interface DropdownMenuLinkProps {
 	 */
 	alignIcon?: 'left' | 'right';
 	className?: string;
+	onClick?(): void;
 }
 
 /**
- * A `<Link>` element inside a dropdown menu.
+ * A `<Button>` element inside a dropdown menu.
  */
-export const DropdownMenuLink = ({
-	to,
+export const DropdownMenuButton = ({
 	children,
-	reloadDocument = false,
 	icon = undefined,
 	alignIcon = 'left',
 	className = '',
-}: DropdownMenuLinkProps) => {
+	onClick = undefined,
+}: DropdownMenuButtonProps) => {
 	const handleClick = (e: React.SyntheticEvent) => {
 		const $target = e.nativeEvent.target as HTMLLinkElement;
 		$target.closest('.dropdown')?.removeAttribute('open');
+
+		if (onClick) {
+			onClick();
+		}
 	};
 
 	return (
-		<Link
-			to={to}
+		<button
 			className={`dropdown-menu-item ${icon ? `has-icon align-icon--${alignIcon}` : ''} ${className}`.trim()}
 			onClick={handleClick}
-			reloadDocument={reloadDocument}
+			type="button"
 		>
 			{icon && alignIcon === 'left' && icon}
 			<span>{children}</span>
 			{icon && alignIcon === 'right' && icon}
-		</Link>
+		</button>
 	);
 };

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,6 +1,7 @@
 import { Dropdown } from './Dropdown';
 import { DropdownTrigger } from './DropdownTrigger';
 import { DropdownMenu } from './DropdownMenu';
+import { DropdownMenuButton } from './DropdownMenuButton';
 import { DropdownMenuText } from './DropdownMenuText';
 import { DropdownMenuLink } from './DropdownMenuLink';
 import { DropdownMenuLinkDescription } from './DropdownMenuLinkDescription';
@@ -9,6 +10,7 @@ export {
 	Dropdown,
 	DropdownTrigger,
 	DropdownMenu,
+	DropdownMenuButton,
 	DropdownMenuText,
 	DropdownMenuLink,
 	DropdownMenuLinkDescription,

--- a/src/components/FormElementGroup.css
+++ b/src/components/FormElementGroup.css
@@ -3,7 +3,7 @@
 	gap: 0;
 }
 
-.form-element-group > *:is(:focus, :active) {
+.form-element-group > *:is(:focus-visible, :active) {
 	z-index: 1;
 }
 

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
 import { useOidc, useOidcUser, OidcUserStatus } from '@axa-fr/react-oidc';
-import { UserIcon as UserIconOutline } from '@heroicons/react/24/outline';
+import {
+	PowerIcon,
+	UserIcon as UserIconOutline,
+} from '@heroicons/react/24/outline';
 import { UserIcon as UserIconSolid } from '@heroicons/react/24/solid';
+import {
+	Dropdown,
+	DropdownTrigger,
+	DropdownMenu,
+	DropdownMenuButton,
+} from './Dropdown';
 import { getLogger } from '../logger';
 
 const logger = getLogger('<User>');
 
 const User = () => {
 	const { oidcUser, oidcUserLoadingState } = useOidcUser();
-	const { login } = useOidc();
+	const { login, logout } = useOidc();
 
 	switch (oidcUserLoadingState) {
 		case OidcUserStatus.Loading:
@@ -40,10 +49,24 @@ const User = () => {
 			);
 		default:
 			return (
-				<div className="App-navbar__item">
-					<UserIconSolid />
-					{oidcUser.name}
-				</div>
+				<Dropdown name="navbar-dropdown">
+					<DropdownTrigger type="navbar-item">
+						<UserIconSolid />
+						{oidcUser.name}
+					</DropdownTrigger>
+					<DropdownMenu align="right">
+						<DropdownMenuButton
+							icon={<PowerIcon />}
+							className="logout"
+							onClick={() => {
+								logout('/').catch(logger.error);
+							}}
+							key="logout"
+						>
+							Log out
+						</DropdownMenuButton>
+					</DropdownMenu>
+				</Dropdown>
 			);
 	}
 };

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,8 @@
 
 	--badge--background-color: var(--color--gray--darker);
 	--badge--color: white;
+
+	--outline: 2px solid var(--color--blue);
 }
 
 body {
@@ -66,6 +68,10 @@ body {
 *:before,
 *:after {
 	box-sizing: border-box;
+
+	&:focus-visible {
+		outline: var(--outline);
+	}
 }
 
 nav ul,

--- a/src/stories/Dropdown.stories.tsx
+++ b/src/stories/Dropdown.stories.tsx
@@ -9,6 +9,7 @@ import {
 	Dropdown,
 	DropdownTrigger,
 	DropdownMenu,
+	DropdownMenuButton,
 	DropdownMenuText,
 	DropdownMenuLink,
 	DropdownMenuLinkDescription,
@@ -108,6 +109,36 @@ export const WithIconInTrigger: Story = {
 				<DropdownMenuLink to="/" key="item3">
 					Item 3
 				</DropdownMenuLink>
+			</DropdownMenu>,
+		],
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ height: '250px' }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const UsingButtons: Story = {
+	args: {
+		children: [
+			<DropdownTrigger>Toggle menu</DropdownTrigger>,
+			<DropdownMenu>
+				<DropdownMenuLink to="/" key="item1">
+					This is a link
+				</DropdownMenuLink>
+				<DropdownMenuButton
+					onClick={() => {
+						// We want a low-touch way of showing we clicked a button.
+						// eslint-disable-next-line no-alert
+						window.alert('You clicked a button.');
+					}}
+					key="item2"
+				>
+					This is a button
+				</DropdownMenuButton>
 			</DropdownMenu>,
 		],
 	},


### PR DESCRIPTION
This PR adds a user menu with a lone "Log out" link. That part was simple, but there were three prerequisite changes:

- Refactoring our `Button` component to extend native buttons for a cleaner prop definition
- Cleaning up our focus styling on interactive elements
- Adding a new `DropdownMenuButton` component so that dropdowns can contain links _or_ buttons

**Testing:**
1. Log in
2. Click your username in the top right and then the "Log out" button
3. ✅ You should be logged out and sent to the home page
4. Click "Log in"
5. ✅ You should be prompted to log in; if you aren't, and you're just round-tripped back to the PDC with a valid session, ❌ that's bad because it means we didn't kill the Keycloak session.

Resolves #619