### PR TITLE
Make orgs discoverable

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -1,5 +1,9 @@
 # Recent Changes to the PDC
 
+## April 2024
+
+- Add Organizations to the PDC
+
 ## February 2024
 
 - Add bulk upload of proposal data via CSV

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useOidc } from '@axa-fr/react-oidc';
 import {
+	BuildingOffice2Icon as BuildingOffice2IconOutline,
 	CommandLineIcon as CommandLineIconOutline,
 	DocumentTextIcon as DocumentTextIconOutline,
 	InformationCircleIcon as InformationCircleIconOutline,
 	SquaresPlusIcon as SquaresPlusIconOutline,
 } from '@heroicons/react/24/outline';
 import {
+	BuildingOffice2Icon as BuildingOffice2IconSolid,
 	CommandLineIcon as CommandLineIconSolid,
 	DocumentTextIcon as DocumentTextIconSolid,
 	InformationCircleIcon as InformationCircleIconSolid,
@@ -28,6 +30,20 @@ const AppNavbar = () => {
 	return (
 		<nav className="App-navbar">
 			<ul>
+				<li>
+					<NavLink to="/organizations" className="App-navbar__item">
+						{({ isActive }) => (
+							<>
+								{isActive ? (
+									<BuildingOffice2IconSolid />
+								) : (
+									<BuildingOffice2IconOutline />
+								)}
+								Organizations
+							</>
+						)}
+					</NavLink>
+				</li>
 				{isAuthenticated && (
 					<>
 						<li>

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -124,6 +124,12 @@
 	right: 3px;
 }
 
+.button--block {
+	display: flex;
+	justify-content: center;
+	inline-size: 100%;
+}
+
 .button--link-style {
 	--button--primary-color: var(--color--blue);
 	--button--primary-color: var(--color--blue--dark);

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -71,6 +71,12 @@
 	--button--primary-color--accent: var(--color--gray--darker);
 	--button--contrast-color: var(--color--gray--lighter);
 	--button--contrast-color--accent: var(--color--gray--light);
+
+	/* Special styling for non-inverted and non-bordered mode. */
+	&:not(.button--inverted, .button--bordered) {
+		--button--contrast-color: var(--color--gray--light);
+		--button--contrast-color--accent: var(--color--gray);
+	}
 }
 
 .button--color-blue {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -20,6 +20,10 @@ interface ButtonProps {
 	 * Adds a notification disc to the button.
 	 */
 	notification?: boolean;
+	/**
+	 * Make the button occupy maximum available horizontal space.
+	 */
+	block?: boolean;
 	disabled?: boolean;
 	/**
 	 * Optional click handler
@@ -45,6 +49,7 @@ export const Button = ({
 	inverted = false,
 	bordered = true,
 	notification = false,
+	block = false,
 	disabled = false,
 	onClick = () => true,
 	submit = false,
@@ -63,6 +68,10 @@ export const Button = ({
 
 	if (notification) {
 		buttonClassNames.push('button--notification');
+	}
+
+	if (block) {
+		buttonClassNames.push('button--block');
 	}
 
 	if (linkStyle) {

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -23,7 +23,7 @@ const User = () => {
 				<button
 					className="App-navbar__item"
 					onClick={() => {
-						login('/proposals').catch(logger.error);
+						login('/').catch(logger.error);
 					}}
 					type="button"
 				>

--- a/src/pages/Landing.css
+++ b/src/pages/Landing.css
@@ -4,3 +4,13 @@
 
 	--panel--padding: var(--fixed-spacing--2x);
 }
+
+.launch-buttons {
+	display: flex;
+	gap: var(--fixed-spacing--1x);
+	flex-direction: column;
+
+	&.authenticated {
+		flex-direction: row;
+	}
+}

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -58,7 +58,7 @@ const Landing = () => {
 								inverted
 								block
 								onClick={() => {
-									login('/proposals').catch(logger.error);
+									login('/').catch(logger.error);
 								}}
 							>
 								<UserIcon className="icon" />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useOidc } from '@axa-fr/react-oidc';
-import { DocumentTextIcon } from '@heroicons/react/24/outline';
-import { UserIcon } from '@heroicons/react/24/solid';
+import {
+	BuildingOffice2Icon,
+	DocumentTextIcon,
+	UserIcon,
+} from '@heroicons/react/24/outline';
 import { getLogger } from '../logger';
 import { Panel, PanelBody } from '../components/Panel';
 import { Button } from '../components/Button';
@@ -28,26 +31,50 @@ const Landing = () => {
 						Read more about the project here.
 					</OffsiteLink>
 				</p>
-				{isAuthenticated ? (
-					<Link
-						to="/proposals"
-						className="button button--color-blue button--inverted"
-					>
-						<DocumentTextIcon />
-						View proposals
-					</Link>
-				) : (
-					<Button
-						color="blue"
-						inverted
-						onClick={() => {
-							login('/proposals').catch(logger.error);
-						}}
-					>
-						<UserIcon className="icon" />
-						Log in
-					</Button>
-				)}
+				<div
+					className={`launch-buttons ${isAuthenticated ? 'authenticated' : ''}`}
+				>
+					{isAuthenticated ? (
+						<>
+							<Link
+								to="/organizations"
+								className="button button--color-blue button--inverted button--block"
+							>
+								<BuildingOffice2Icon />
+								View organizations
+							</Link>
+							<Link
+								to="/proposals"
+								className="button button--color-blue button--inverted button--block"
+							>
+								<DocumentTextIcon />
+								View proposals
+							</Link>
+						</>
+					) : (
+						<>
+							<Button
+								color="blue"
+								inverted
+								block
+								onClick={() => {
+									login('/proposals').catch(logger.error);
+								}}
+							>
+								<UserIcon className="icon" />
+								Log in
+							</Button>
+							<Link
+								to="/organizations"
+								className="button button--color-gray button--block"
+							>
+								<BuildingOffice2Icon />
+								View public organization data
+							</Link>
+						</>
+					)}
+				</div>
+
 				<dl>
 					{!isAuthenticated && (
 						<Dli>


### PR DESCRIPTION
We already had org table and detail pages, but you had to know the URL to get to them. We're actually ready for folks to use them, so… this PR:

- Adds an Organizations item to the navbar (even when logged-out)
- Updates the landing page with a pre-login link to the orgs and a post-login link to proposals and orgs

<details>
<summary>Click to view before/after comparison screenshots…</summary>

**Before, logged out:**
<img width="1356" alt="before-logged-out" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/8ba0f36f-7c06-4e85-a836-29fea697c997">

**After, logged out:**
<img width="1356" alt="after-logged-out" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/4c37a5a8-2f66-4596-8dbb-263a8e0618ca">

**Before, logged in:**
<img width="1356" alt="before-logged-in" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/769f3b98-c848-4d29-993a-99f56d701991">

**After, logged in:**
<img width="1356" alt="after-logged-in" src="https://github.com/PhilanthropyDataCommons/front-end/assets/4731/293ed94b-2f31-40cc-bf6e-1f41dd436877">

</details>

**Testing:**
- ✅ See the Organizations item in the navbar (whether logged in or not)
- ✅ See the new landing page button options (in logged out and logged in state)
- ✅ Note that after logging in, you are returned to the landing page (not the proposals table)

Closes #604 
Closes #561