### PR TITLE
Convert Proposal's text-wrapper to a ToggleSwitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
 					"optionalDependencies": false
 				}
 			],
+			"jsx-a11y/label-has-associated-control": [
+				"error",
+				{
+					"assert": "either"
+				}
+			],
 			"react/function-component-definition": [
 				"error",
 				{

--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -85,6 +85,12 @@
 .panel-actions {
 	display: flex;
 	gap: var(--fixed-spacing--1x);
+	align-items: center;
+
+	&.switches {
+		padding-inline-end: var(--button--padding-x);
+		gap: var(--fixed-spacing--2x);
+	}
 }
 
 .panel-body {

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { Panel, PanelHeader, PanelBody, PanelActions } from './Panel';
 import { ProposalListTable } from './ProposalListTable';
-import { Button } from './Button';
 import { Search } from './Search';
+import { ToggleSwitch } from './ToggleSwitch';
 
 interface ProposalListTablePanelProps {
 	fieldNames: Record<string, string>;
@@ -23,7 +22,7 @@ export const ProposalListTablePanel = ({
 }: ProposalListTablePanelProps) => {
 	const [wrap, setWrap] = useState(false);
 
-	const handleWrapClick = () => setWrap((previous) => !previous);
+	const handleWrapChange = () => setWrap((previous) => !previous);
 
 	const hasProposals = proposals.length > 0;
 	const hasSearchQuery = searchQuery !== '';
@@ -43,11 +42,10 @@ export const ProposalListTablePanel = ({
 					<Search onSearch={onSearch} initialQuery={searchQuery} />
 				</PanelActions>
 				{hasProposals && (
-					<PanelActions>
-						<Button onClick={handleWrapClick} color={wrap ? 'blue' : 'gray'}>
-							<Bars3BottomLeftIcon className="icon" />
-							Toggle wrapping
-						</Button>
+					<PanelActions className="switches">
+						<ToggleSwitch checked={wrap} onChange={handleWrapChange}>
+							Wrap long text
+						</ToggleSwitch>
 					</PanelActions>
 				)}
 			</PanelHeader>

--- a/src/components/ToggleSwitch.css
+++ b/src/components/ToggleSwitch.css
@@ -1,0 +1,65 @@
+:root {
+	--toggle-switch--width: 2.5em;
+	--toggle-switch--height: calc(1em * var(--line-height) * 1px);
+	--toggle-switch--inset: 0.15em;
+	--toggle-switch--background-color--off: var(--color--gray);
+	--toggle-switch--background-color--on: var(--color--blue);
+	--toggle-switch--indicator-size: calc(
+		100% - (var(--toggle-switch--inset) * 2)
+	);
+}
+
+.toggle-switch {
+	display: inline-flex;
+	gap: 0.75ch;
+	cursor: pointer;
+
+	> input[type='checkbox'] {
+		all: unset;
+		box-sizing: border-box;
+
+		--toggle-switch--background-color: var(
+			--toggle-switch--background-color--off
+		);
+		--toggle-switch--indicator-position: var(--toggle-switch--inset);
+
+		display: block;
+		position: relative;
+		width: var(--toggle-switch--width);
+		height: var(--toggle-switch--height);
+		border-radius: 5em;
+		background-color: var(--toggle-switch--background-color);
+
+		transition: var(--transition-duration) background-color;
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: 0;
+			top: var(--toggle-switch--inset);
+			height: var(--toggle-switch--indicator-size);
+			aspect-ratio: 1;
+			border-radius: 5em;
+			background-color: white;
+			transform: translateX(var(--toggle-switch--indicator-position));
+
+			transition: var(--transition-duration) transform;
+		}
+
+		&:checked {
+			--toggle-switch--background-color: var(
+				--toggle-switch--background-color--on
+			);
+			--toggle-switch--indicator-position: calc(
+				var(--toggle-switch--width) - var(--toggle-switch--indicator-size) -
+					(var(--toggle-switch--inset) * 3)
+			);
+		}
+
+		&:focus,
+		&:active {
+			outline: var(--outline);
+			outline-offset: 1px;
+		}
+	}
+}

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import './ToggleSwitch.css';
+
+interface ToggleSwitchProps {
+	children: React.ReactNode;
+	checked?: boolean;
+	onChange?(): void;
+}
+
+/**
+ * Toggle checkbox that looks like a little slider button.
+ */
+export const ToggleSwitch = ({
+	children,
+	checked = false,
+	onChange = undefined,
+}: ToggleSwitchProps) => (
+	<label className="toggle-switch">
+		<input
+			type="checkbox"
+			onChange={onChange}
+			// Without an onChange handler, this can't be a controlled component,
+			// so we use `defaultChecked` instead.
+			checked={onChange ? checked : undefined}
+			defaultChecked={onChange ? undefined : checked}
+		/>
+		<span>{children}</span>
+	</label>
+);

--- a/src/stories/ToggleSwitch.stories.tsx
+++ b/src/stories/ToggleSwitch.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ToggleSwitch } from '../components/ToggleSwitch';
+
+const meta = {
+	component: ToggleSwitch,
+	tags: ['autodocs'],
+} satisfies Meta<typeof ToggleSwitch>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		children: 'Toggle me',
+	},
+};
+
+export const Checked: Story = {
+	args: {
+		children: 'Toggle me',
+		checked: true,
+	},
+};


### PR DESCRIPTION
This PR is the output of #620. It adds a new `ToggleSwitch` component in the style of iOS toggle switches (which have since broken out of iOS-land to be a pretty widely-used UI component, e.g. in [Tailwind](https://tailwindui.com/components/application-ui/forms/toggles) or [Bootstrap](https://getbootstrap.com/docs/5.0/forms/checks-radios/#switches)), and it converts our button-style wrapping toggle for the proposals table to use it, with the eventual aim of using it for "Show only my proposals" in #622.

**Before:**

https://github.com/PhilanthropyDataCommons/front-end/assets/4731/64d40b45-1732-4cb0-b5a5-0c8405e50ed8

**After:**

https://github.com/PhilanthropyDataCommons/front-end/assets/4731/76ddc449-067c-4052-a366-b1a60c4aa92b

### Testing

- Examine the [Storybook](https://deploy-preview-704--philanthropy-data-commons-viewer.netlify.app/storybook/?path=/docs/stories-toggleswitch--docs)
- Compare the "Toggle wrapping" functionality on `main`/production's `/proposals` table with this one

Resolves #620 (in that by accepting this change, we're committing to this UI for the proposal-filter too)