### PR TITLE
Make user IDs available for use in dependent API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "front-end",
 			"version": "0.1.0",
 			"dependencies": {
-				"@axa-fr/react-oidc": "^7.22.3",
+				"@axa-fr/react-oidc": "^7.22.4",
 				"@fontsource/source-sans-pro": "^5.0.8",
 				"@heroicons/react": "^2.1.3",
 				"@pdc/sdk": "^0.7.1",
@@ -81,27 +81,27 @@
 			}
 		},
 		"node_modules/@axa-fr/oidc-client": {
-			"version": "7.22.3",
-			"resolved": "https://registry.npmjs.org/@axa-fr/oidc-client/-/oidc-client-7.22.3.tgz",
-			"integrity": "sha512-WiWG9vvHa0yl1theLcfNNbu9Hmp8j8lSY+2phnwiFmv4NCvXFPk0JixGvFV3QaMcvd4hHcgFrzO5mqXaPtdQng==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@axa-fr/oidc-client/-/oidc-client-7.22.4.tgz",
+			"integrity": "sha512-7NFvpWSRZcJM1bnWYYeOCe3rad4v6xok1y0+9GFmHIOKZSuU/ex/4uQ3D3pxgguGi/sgfkrixot/8vWm0EESfQ==",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@axa-fr/oidc-client-service-worker": "7.22.3"
+				"@axa-fr/oidc-client-service-worker": "7.22.4"
 			}
 		},
 		"node_modules/@axa-fr/oidc-client-service-worker": {
-			"version": "7.22.3",
-			"resolved": "https://registry.npmjs.org/@axa-fr/oidc-client-service-worker/-/oidc-client-service-worker-7.22.3.tgz",
-			"integrity": "sha512-ngJZ20vZ4HIktPWk7uYkhZS675KBtNdG8HDxR2ViMEt7JbE7Wz3BigVdjpur0UvzZwNlzUo1aZR4Eyowawr7+A=="
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@axa-fr/oidc-client-service-worker/-/oidc-client-service-worker-7.22.4.tgz",
+			"integrity": "sha512-bL7Wq+510tDxRSe5H7/AbgYyQTggnFJAd9fc6jSDb4eJWtE2E2ZWfJfg6wmpInHKP0xlFac7mHkX5CDZwac00A=="
 		},
 		"node_modules/@axa-fr/react-oidc": {
-			"version": "7.22.3",
-			"resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-7.22.3.tgz",
-			"integrity": "sha512-RhQXsu+zEmo7drRCqgosdo5Pwles2XGOrtAPmfYDJJiJwESJO/dfQyR+nfX51chxEx9zFhvgR7bU3I0O/205Dg==",
+			"version": "7.22.4",
+			"resolved": "https://registry.npmjs.org/@axa-fr/react-oidc/-/react-oidc-7.22.4.tgz",
+			"integrity": "sha512-s4SVoBud+R59r5dhWLGTnYxEJQ7vh5LKuBfV44d5zgmIfc6671WXJkHwu3XPZr08GntuPvK2vRpmuwmQVfVivQ==",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@axa-fr/oidc-client": "7.22.3",
-				"@axa-fr/oidc-client-service-worker": "7.22.3"
+				"@axa-fr/oidc-client": "7.22.4",
+				"@axa-fr/oidc-client-service-worker": "7.22.4"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@axa-fr/react-oidc": "^7.22.4",
 				"@fontsource/source-sans-pro": "^5.0.8",
 				"@heroicons/react": "^2.1.3",
-				"@pdc/sdk": "^0.7.1",
+				"@pdc/sdk": "^0.8.1",
 				"dayjs": "^1.11.10",
 				"jsonpath-plus": "^8.1.0",
 				"pino": "^8.20.0",
@@ -5586,9 +5586,9 @@
 			}
 		},
 		"node_modules/@pdc/sdk": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.7.1.tgz",
-			"integrity": "sha512-UfC1UEoJM8pc4+pz82Q9tu8pi68BxFge+UHuxzJ+26pb+2ec5ziBvU1pWGjvcT37w58R6bGNWjfpf3OimFtDsg=="
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.8.1.tgz",
+			"integrity": "sha512-dYq/G4A0yg9c29B3XbA2YKKq5AZ8m5Hx86gi+ioN1mLJECNu5rmiec/wFLplPHIyHWJrSn8oGUkUQlKvL8CPtg=="
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"dependencies": {
-		"@axa-fr/react-oidc": "^7.22.3",
+		"@axa-fr/react-oidc": "^7.22.4",
 		"@fontsource/source-sans-pro": "^5.0.8",
 		"@heroicons/react": "^2.1.3",
 		"@pdc/sdk": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"@axa-fr/react-oidc": "^7.22.4",
 		"@fontsource/source-sans-pro": "^5.0.8",
 		"@heroicons/react": "^2.1.3",
-		"@pdc/sdk": "^0.7.1",
+		"@pdc/sdk": "^0.8.1",
 		"dayjs": "^1.11.10",
 		"jsonpath-plus": "^8.1.0",
 		"pino": "^8.20.0",

--- a/src/UserContext.ts
+++ b/src/UserContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+import type { User } from '@pdc/sdk';
+
+const emptyUser = {
+	id: 0,
+	authenticationId: '',
+	createdAt: new Date(0),
+};
+
+export const UserContext = createContext<User>(emptyUser);

--- a/src/UserProvider.tsx
+++ b/src/UserProvider.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react';
+import { useOidcUser } from '@axa-fr/react-oidc';
+import { useUser } from './pdc-api';
+import { UserContext } from './UserContext';
+
+interface UserProviderProps {
+	children: React.ReactNode;
+}
+
+export const UserProvider = ({ children }: UserProviderProps) => {
+	const { oidcUser } = useOidcUser();
+	const emptyUser = {
+		id: 0,
+		authenticationId: '',
+		createdAt: new Date(0),
+	};
+	const [currentUserState, setCurrentUserState] = useState(emptyUser);
+	const [user] = useUser(oidcUser.sub ?? '');
+	useEffect(() => {
+		if (user !== null) {
+			setCurrentUserState(user);
+		}
+	}, [user]);
+	return (
+		<UserContext.Provider value={currentUserState}>
+			{children}
+		</UserContext.Provider>
+	);
+};
+
+

--- a/src/oidc-config.ts
+++ b/src/oidc-config.ts
@@ -18,6 +18,7 @@ const getConfiguration = (
 		redirect_uri: `${window.location.origin}/authentication/callback`,
 		silent_redirect_uri: `${window.location.origin}/authentication/silent-callback`,
 		scope: 'openid',
+        preload_user_info: true,
 	};
 };
 

--- a/src/oidc-config.ts
+++ b/src/oidc-config.ts
@@ -18,7 +18,7 @@ const getConfiguration = (
 		redirect_uri: `${window.location.origin}/authentication/callback`,
 		silent_redirect_uri: `${window.location.origin}/authentication/silent-callback`,
 		scope: 'openid',
-        preload_user_info: true,
+		preload_user_info: true,
 	};
 };
 

--- a/src/pages/AddData.tsx
+++ b/src/pages/AddData.tsx
@@ -15,6 +15,7 @@ import { BaseFields } from '../components/BaseFields';
 import { BulkUploaderFilePicker } from '../components/BulkUploaderFilePicker';
 import { BulkUploadList } from '../components/BulkUploadList';
 import './AddData.css';
+import { UserProvider } from '../UserProvider';
 
 const REFRESH_BULK_UPLOADS_INTERVAL = 5000;
 
@@ -75,28 +76,30 @@ const AddDataLoader = () => {
 	}, [bulkUploadResponse, refreshBulkUploads]);
 
 	return (
-		<PanelGrid sidebarred>
-			<PanelGridItem>
-				<Panel>
-					<PanelHeader padded={false}>
-						<NavLink to="/add-data" className="new-bulk-upload-link">
-							<DocumentPlusIcon className="icon" />
-							New bulk upload
-						</NavLink>
-					</PanelHeader>
-					<PanelBody padded={false}>
-						<BulkUploadList uploads={bulkUploads} />
-					</PanelBody>
-				</Panel>
-			</PanelGridItem>
-			<PanelGridItem>
-				<NewBulkUploadPanel
-					apiUrl={new URL('/', process.env.REACT_APP_API_URL)}
-					bulkUploader={<BulkUploader onBulkUpload={refreshBulkUploads} />}
-					baseFieldsLoader={<BaseFieldsLoader />}
-				/>
-			</PanelGridItem>
-		</PanelGrid>
+		<UserProvider>
+			<PanelGrid sidebarred>
+				<PanelGridItem>
+					<Panel>
+						<PanelHeader padded={false}>
+							<NavLink to="/add-data" className="new-bulk-upload-link">
+								<DocumentPlusIcon className="icon" />
+								New bulk upload
+							</NavLink>
+						</PanelHeader>
+						<PanelBody padded={false}>
+							<BulkUploadList uploads={bulkUploads} />
+						</PanelBody>
+					</Panel>
+				</PanelGridItem>
+				<PanelGridItem>
+					<NewBulkUploadPanel
+						apiUrl={new URL('/', process.env.REACT_APP_API_URL)}
+						bulkUploader={<BulkUploader onBulkUpload={refreshBulkUploads} />}
+						baseFieldsLoader={<BaseFieldsLoader />}
+					/>
+				</PanelGridItem>
+			</PanelGrid>
+		</UserProvider>
 	);
 };
 

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -131,10 +131,10 @@ const ProposalDetailLoader = () => {
 	const [baseFields] = useBaseFields();
 
 	return (
-		<PanelGrid sidebarred>
-			<ProposalListGridLoader baseFields={baseFields} />
-			<ProposalDetailPanelLoader baseFields={baseFields} />
-		</PanelGrid>
+			<PanelGrid sidebarred>
+				<ProposalListGridLoader baseFields={baseFields} />
+				<ProposalDetailPanelLoader baseFields={baseFields} />
+			</PanelGrid>
 	);
 };
 

--- a/src/pages/ProposalList.tsx
+++ b/src/pages/ProposalList.tsx
@@ -11,6 +11,7 @@ import { mapProposals } from '../map-proposals';
 import { PanelGrid, PanelGridItem } from '../components/PanelGrid';
 import { ProposalListTablePanel } from '../components/ProposalListTablePanel';
 import { mapFieldNames } from '../utils/baseFields';
+import { UserProvider } from '../UserProvider';
 
 const ProposalListLoader = () => {
 	const navigate = useNavigate();
@@ -46,16 +47,18 @@ const ProposalListLoader = () => {
 	const mappedProposals = mapProposals(fields, proposals.entries);
 
 	return (
-		<PanelGrid>
-			<PanelGridItem>
-				<ProposalListTablePanel
-					fieldNames={mapFieldNames(fields)}
-					proposals={mappedProposals}
-					searchQuery={query}
-					onSearch={handleSearch}
-				/>
-			</PanelGridItem>
-		</PanelGrid>
+		<UserProvider>
+			<PanelGrid>
+				<PanelGridItem>
+					<ProposalListTablePanel
+						fieldNames={mapFieldNames(fields)}
+						proposals={mappedProposals}
+						searchQuery={query}
+						onSearch={handleSearch}
+					/>
+				</PanelGridItem>
+			</PanelGrid>
+		</UserProvider>
 	);
 };
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useOidcFetch } from '@axa-fr/react-oidc';
-import { Organization, OrganizationBundle } from '@pdc/sdk';
+import { User, Organization, OrganizationBundle } from '@pdc/sdk';
 import { getLogger } from './logger';
 
 const logger = getLogger('pdc-api');
@@ -268,6 +268,14 @@ const useOrganizations = (page: string, count: string) =>
 		}),
 	);
 
+const useUser = (authenticationId: string) =>
+	usePdcApi<User>(
+		'/users',
+		new URLSearchParams({
+			_authenticationId: authenticationId,
+		}),
+	);
+
 export {
 	PROPOSALS_DEFAULT_COUNT,
 	PROPOSALS_DEFAULT_PAGE,
@@ -285,6 +293,7 @@ export {
 	useOrganizations,
 	useProviderData,
 	useRegisterBulkUploadCallback,
+	useUser,
 };
 
 export type { ApiBaseField, ApiBulkUpload, ApiProposal };


### PR DESCRIPTION
**This is a draft PR, it brings with it a pretty significant design choice that I'd like to review before moving forward. ~~Also, it contains an update to the pdc-sdk which should be a separate dependabot PR.~~**



This PR adds an additional context provider to the front-end application that provides the User(retrieved from the API by the subject of the OIDC session in the front-end) as global context to the rest of the application, which can be retrieved via the 'useContext' hook. There is currently no code in the commits that use this context, but it can be tested locally, e.g.
```ts
import React, {useContext} from 'React'
import {UserContext} from '../UserContext'


const MyComponent = () => {
          const user = useContext(UserContext);
          console.log(user) //or any other operation
```

[Context is an officially recommended approach to persisting user data as per the React Docs](https://react.dev/learn/passing-data-deeply-with-context#use-cases-for-context), and furthermore is the approach used, at least in part, by our current auth provider. However, there is something definitely awry about wrapping our application in two different User contexts. 

There is certainly also a viable approach in 'preflight'ing our api calls, but either way (as discussed in my first commit) I believe we will at least need to employ the new 'preload_user_info' feature of the 'react-oidc' package, in order to both acquire the oidcUser subject and the User object from the database. 

 
Closes #702