### PR TITLE
Only show the user their own bulk uploads

### DIFF
--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -176,7 +176,11 @@ interface ApiBulkUploads {
 	total: number;
 }
 
-const useBulkUploads = () => usePdcApi<ApiBulkUploads>('/bulkUploads');
+const useBulkUploads = () =>
+	usePdcApi<ApiBulkUploads>(
+		'/bulkUploads',
+		new URLSearchParams({ createdBy: 'me' }),
+	);
 
 interface ApiProposal {
 	id: number;


### PR DESCRIPTION
This PR scopes the bulk upload lists to only those created by the requesting user. It does so statically — i.e., without allowing the user to remove the scope and view bulk uploads from other people, even if they're authorized to. This is an intentional front-end UX choice until we build out a fuller interface for admins to see other people’s bulk uploads (if ever needed). It’s not a security concern; the API handles making sure users only see what they’re authorized to.

The `createdBy=me` value is a magic value that tells the API that the scope should be “the user ID of the requesting user”. That value doesn't work _yet_, but will once https://github.com/PhilanthropyDataCommons/service/pull/961 is merged.

**Testing:**
1. On `main`, on a multi-user system where multiple users have added bulk uploads, go to the Add Data page
2. ❌ No matter who you are logged-in as, all bulk uploads are show in the history sidebar
3. Switch to this branch and check again
4. ✅ You should only see your current user's uploads

🤚 This only affects the uploads, not any proposals or other objects inserted by that upload.

Delivers #697