### PR TITLE
Make some UI improvements

### DIFF
--- a/src/components/Panel/Panel.css
+++ b/src/components/Panel/Panel.css
@@ -17,6 +17,7 @@
 
 	display: flex;
 	justify-content: space-between;
+	align-items: flex-start;
 	gap: var(--fixed-spacing--2x);
 }
 
@@ -90,6 +91,7 @@
 	&.switches {
 		padding-inline-end: var(--button--padding-x);
 		gap: var(--fixed-spacing--2x);
+		align-self: center;
 	}
 }
 

--- a/src/components/ToggleSwitch.css
+++ b/src/components/ToggleSwitch.css
@@ -11,8 +11,10 @@
 
 .toggle-switch {
 	display: inline-flex;
-	gap: 0.75ch;
+	gap: 1ch;
 	cursor: pointer;
+
+	font-weight: var(--font-weight--medium);
 
 	> input[type='checkbox'] {
 		all: unset;


### PR DESCRIPTION
Two quick UI improvements that fix some rough edges:

- Toggle switches have heavier-weight labels to better distinguish them from content text
- Panel actions remain positioned in the top right of the panel even when the title wraps (with an exception for switches, which I'd like to improve in the future)

**Testing:**
- The "Wrap long text" toggle switch on `/proposals` was normal-weight, now it's heavy
- When drilling into an organization detail page at `/organization/:id`, the Data Provider button wasn't tucked neatly in the top right corner, it was down a bit; now it's neat

No associated issues, these are just little things noticed while testing.