### PR TITLE
Update EIN to Tax ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@axa-fr/react-oidc": "^7.22.4",
 				"@fontsource/source-sans-pro": "^5.0.8",
 				"@heroicons/react": "^2.1.3",
-				"@pdc/sdk": "^0.8.1",
+				"@pdc/sdk": "^0.9.1",
 				"dayjs": "^1.11.11",
 				"jsonpath-plus": "^8.1.0",
 				"pino": "^9.0.0",
@@ -5586,9 +5586,9 @@
 			}
 		},
 		"node_modules/@pdc/sdk": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.8.1.tgz",
-			"integrity": "sha512-dYq/G4A0yg9c29B3XbA2YKKq5AZ8m5Hx86gi+ioN1mLJECNu5rmiec/wFLplPHIyHWJrSn8oGUkUQlKvL8CPtg=="
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.9.1.tgz",
+			"integrity": "sha512-QvCbocSDraVtcft1Cd3g264rhyLIlApcYDLJ3kjiSQhsYbLdHOVZPf53ZH6zwS9NfFAwKH6SuvhY4W5AM8CZWg=="
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"@axa-fr/react-oidc": "^7.22.4",
 		"@fontsource/source-sans-pro": "^5.0.8",
 		"@heroicons/react": "^2.1.3",
-		"@pdc/sdk": "^0.8.1",
+		"@pdc/sdk": "^0.9.1",
 		"dayjs": "^1.11.11",
 		"jsonpath-plus": "^8.1.0",
 		"pino": "^9.0.0",

--- a/src/components/OrganizationDetailPanel.tsx
+++ b/src/components/OrganizationDetailPanel.tsx
@@ -32,7 +32,7 @@ const OrganizationDetailPanel = ({
 	organization,
 	children = undefined,
 }: OrganizationDetailPanelProps) => {
-	const { id, name, employerIdentificationNumber } = organization;
+	const { id, name, taxId } = organization;
 	const { isAuthenticated } = useOidc();
 
 	const showDataProviderMenu = isAuthenticated;
@@ -43,9 +43,7 @@ const OrganizationDetailPanel = ({
 				<PanelTitleWrapper>
 					<PanelTitle>{name}</PanelTitle>
 					<PanelTitleTags>
-						{employerIdentificationNumber && (
-							<PanelTag badge="EIN">{employerIdentificationNumber}</PanelTag>
-						)}
+						{taxId && <PanelTag badge="Tax ID">{taxId}</PanelTag>}
 					</PanelTitleTags>
 				</PanelTitleWrapper>
 				<PanelActions>

--- a/src/components/OrganizationListGrid.tsx
+++ b/src/components/OrganizationListGrid.tsx
@@ -25,9 +25,7 @@ export const OrganizationListGrid = ({
 				key={organization.id}
 			>
 				<ListGridItemTitle>{organization.name}</ListGridItemTitle>
-				<ListGridItemDetails>
-					{organization.employerIdentificationNumber}
-				</ListGridItemDetails>
+				<ListGridItemDetails>{organization.taxId}</ListGridItemDetails>
 			</ListGridItem>
 		)}
 	/>

--- a/src/components/OrganizationListTable.tsx
+++ b/src/components/OrganizationListTable.tsx
@@ -25,12 +25,12 @@ const OrganizationListTableRow = ({
 	return (
 		<TableRow onClick={handleRowClick}>
 			<RowCell>{organization.name}</RowCell>
-			<RowCell>{organization.employerIdentificationNumber}</RowCell>
+			<RowCell>{organization.taxId}</RowCell>
 		</TableRow>
 	);
 };
 
-const DEFAULT_ORGANIZATION_COLUMNS = ['Name', 'EIN'];
+const DEFAULT_ORGANIZATION_COLUMNS = ['Name', 'Tax ID'];
 
 interface OrganizationListTableProps {
 	organizations: OrganizationBundle;

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -39,7 +39,7 @@ const ProposalDetailPanel = ({
 					{applicant && (
 						<PanelTag icon={<BuildingOffice2Icon />}>{applicant}</PanelTag>
 					)}
-					{applicantId && <PanelTag badge="EIN">{applicantId}</PanelTag>}
+					{applicantId && <PanelTag badge="Tax ID">{applicantId}</PanelTag>}
 				</PanelTitleTags>
 			</PanelTitleWrapper>
 		</PanelHeader>

--- a/src/pages/OrganizationDetail.tsx
+++ b/src/pages/OrganizationDetail.tsx
@@ -128,7 +128,7 @@ const OrganizationDetailPanelLoader = () => {
 	if (organization === null) {
 		const dummyOrganization: Organization = {
 			id: 0,
-			employerIdentificationNumber: '00-0000000',
+			taxId: '00-0000000',
 			name: 'Loading...',
 			createdAt: new Date('2024-03-06'),
 		};
@@ -170,7 +170,7 @@ const OrganizationDetailPanelLoader = () => {
 				<PanelGridItem key="platformPanel">
 					<DataPlatformProviderLoader
 						provider={provider}
-						externalId={organization.employerIdentificationNumber}
+						externalId={organization.taxId}
 						onClose={() => {
 							navigate(`/organizations/${organizationId}`);
 						}}


### PR DESCRIPTION
This PR uses the new `taxId` attribute instead of the deprecated `employerIdentificationNumber`.

Resolves #723