### PR TITLE
Use `PlatformProviderResponse` from SDK

### DIFF
--- a/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
+++ b/src/components/DataPlatformProvider/DataPlatformProviderLoader.tsx
@@ -187,6 +187,14 @@ const ProviderPanelLoader = ({
 		return <NoData onClose={onClose} provider={provider} />;
 	}
 	const { parse, name } = providers[provider];
+	/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument --
+	 *
+	 * The `data` property on a `PlatformProviderResponse` gets typed as `any`
+	 * by the SDK generator, but this is a bug in the generator. We can re-enable
+	 * this rule once the upstream bug is fixed.
+	 *
+	 * See: https://github.com/PhilanthropyDataCommons/service/issues/1013#issuecomment-2120839690
+	 */
 	const { applicant, url, values } = parse(selectedProviderData.data);
 	return (
 		<DataPlatformProviderPanel

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -6,6 +6,7 @@ import type {
 	WritableBulkUpload,
 	Organization,
 	OrganizationBundle,
+	PlatformProviderResponse,
 	PresignedPostRequest,
 	WritablePresignedPostRequest,
 	PresignedPostRequestPresignedPost,
@@ -192,13 +193,6 @@ const useProposalsByOrganizationId = (
 			organization: organizationId,
 		}),
 	);
-
-interface PlatformProviderResponse {
-	createdAt: string;
-	externalId: string;
-	platformProvider: string;
-	data: object;
-}
 
 const useProviderData = (externalId: string) =>
 	usePdcApi<PlatformProviderResponse[]>(


### PR DESCRIPTION
This PR uses the `PlatformProviderResponse` type from the SDK instead of defining our own.

In order to do this, we needed to disable the ESLint complaint about the `data` property being an `any`. ~This is allowable because in this ersatz implementation of a provider response, we don’t know the shape of the data.~ Update: This is not actually quite accurate. See updated context: https://github.com/PhilanthropyDataCommons/service/issues/1013#issuecomment-2120839690

**Testing:**

Just linting should do it. We actually aren't _using_ this type in a visible way, since the current batch of visible platform data is no longer available to the front-end.

Resolves #737