### PR TITLE
Fix BulkUploadListItem metadata reducer

### DIFF
--- a/src/components/BulkUploadListItem.tsx
+++ b/src/components/BulkUploadListItem.tsx
@@ -79,19 +79,13 @@ export const BulkUploadListItem = ({ upload }: BulkUploadListItemProps) => {
 
 	const metadataElements = metadata
 		.filter((datum) => datum !== null)
-		.reduce(
-			(accumulator, datum) =>
-				accumulator === null ? (
-					datum
-				) : (
-					<>
-						{accumulator}
-						{METADATA_DELIMITER}
-						{datum}
-					</>
-				),
-			null,
-		);
+		.reduce((accumulator, datum) => (
+			<>
+				{accumulator}
+				{METADATA_DELIMITER}
+				{datum}
+			</>
+		));
 
 	return (
 		<div className={`bulk-upload-list-item ${status}`}>


### PR DESCRIPTION
This commit drops the initial value from the metadataElements reducer function, along with the conditional statement. As per the MDN docs[1], "if [no initial value is supplied,] the array element at index 0 is used as the initial value." Thus we don't need to specify an initial value, as we default to the first value, which, if it exists, is determined to be not null by the filter function.

Closes #803 