### PR TITLE
Set rowClickDestination value explicitly

### DIFF
--- a/src/components/ProposalListTable.tsx
+++ b/src/components/ProposalListTable.tsx
@@ -21,7 +21,7 @@ interface ProposalListTableRowProps {
 const ProposalListTableRow = ({
 	proposal,
 	columns,
-	rowClickDestination = ProposalDetailDestinations.PROPOSAL_DETAIL_PAGE,
+	rowClickDestination,
 	organizationId = undefined,
 	active = false,
 }: ProposalListTableRowProps) => {
@@ -65,7 +65,7 @@ const ProposalListTableRow = ({
 interface ProposalListTableProps {
 	fieldNames: Record<string, string>;
 	proposals: FrontEndProposal[];
-	rowClickDestination?: ProposalDetailDestinations;
+	rowClickDestination: ProposalDetailDestinations;
 	organizationId?: number;
 	wrap?: boolean;
 	columns?: string[];
@@ -97,7 +97,7 @@ const ProposalListTable = ({
 	proposals,
 	columns = DEFAULT_PROPOSAL_COLUMNS,
 	wrap = false,
-	rowClickDestination = ProposalDetailDestinations.PROPOSAL_DETAIL_PAGE,
+	rowClickDestination,
 	organizationId = undefined,
 	activeProposalId = undefined,
 }: ProposalListTableProps) => (

--- a/src/components/ProposalListTablePanel.tsx
+++ b/src/components/ProposalListTablePanel.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import { FrontEndProposal } from '../interfaces/FrontEndProposal';
 import { Panel, PanelHeader, PanelBody, PanelActions } from './Panel';
-import { ProposalListTable } from './ProposalListTable';
+import {
+	ProposalDetailDestinations,
+	ProposalListTable,
+} from './ProposalListTable';
 import { Search } from './Search';
 import { ToggleSwitch } from './ToggleSwitch';
 
@@ -55,6 +58,9 @@ export const ProposalListTablePanel = ({
 						fieldNames={fieldNames}
 						proposals={proposals}
 						wrap={wrap}
+						rowClickDestination={
+							ProposalDetailDestinations.PROPOSAL_DETAIL_PAGE
+						}
 					/>
 				) : (
 					<div className="quiet">{generateFallbackMessage()}</div>

--- a/src/stories/ProposalListTable.stories.tsx
+++ b/src/stories/ProposalListTable.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { ProposalListTable } from '../components/ProposalListTable';
+import {
+	ProposalListTable,
+	ProposalDetailDestinations,
+} from '../components/ProposalListTable';
 
 const meta = {
 	component: ProposalListTable,
@@ -171,5 +174,6 @@ export const Default: Story = {
 			'proposal_end_date',
 			'proposal_location_of_work',
 		],
+		rowClickDestination: ProposalDetailDestinations.PROPOSAL_DETAIL_PAGE,
 	},
 };


### PR DESCRIPTION
This commit removes the default values for rowClickDestination in the ProposalListTable and ProposalListTableRow components, and instead passes the PROPOSAL_DETAIL_PAGE value explicitly inside ProposalListTablePanel. This removes redundancy, and ensures that a value is always explicitly passed.

Closes #805 