### PR TITLE
Include Storybook in deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"start": "vite",
 		"build": "npm run build:app && npm run build:storybook",
 		"build:app": "tsc && vite build",
-		"build:storybook": "storybook build -o build/storybook",
+		"build:storybook": "storybook build -o dist/storybook",
 		"storybook": "storybook dev -p 6006",
 		"lint": "npm run lint:eslint && npm run lint:prettier",
 		"lint:prettier": "prettier . --check",


### PR DESCRIPTION
When we migrated to Vite in PR #748, we changed the output directory from `build` to `dist`. We (belatedly) updated our Netlify configuration to match this change, but in doing so left Storybook behind.

Update the output directory of Storybook to match, so that it is included in deploys.