### PR TITLE
Deploy to DigitalOcean App Platform

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,28 @@
+spec:
+  ingress:
+    rules:
+      - component:
+          name: front-end
+        match:
+          path:
+            prefix: /
+  name: pdc-front-end
+  static_sites:
+    - catchall_document: index.html
+      environment_slug: node-js
+      envs:
+        - key: VITE_API_URL
+          scope: BUILD_TIME
+          value: https://api.example.org
+        - key: VITE_OIDC_AUTHORITY
+          scope: BUILD_TIME
+          value: https://auth.example.org/realms/pdc
+        - key: VITE_OIDC_CLIENT_ID
+          scope: BUILD_TIME
+          value: your-client-id
+      github:
+        branch: main
+        deploy_on_push: true
+        repo: PhilanthropyDataCommons/front-end
+      name: front-end
+      source_dir: /

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ VITE_OIDC_CLIENT_ID=example-front-end
 # The API URL is the location of a running PhilanthropyDataCommons/service instance
 # https://github.com/PhilanthropyDataCommons/service
 VITE_API_URL=https://api.example.com
+
+# Show a link to Storybook in the Developers menu, defaults to false
+#VITE_SHOW_STORYBOOK=true

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Then run `npm start`.
 The environment variables documented in `.env.example`
 will need to be configured in your deployment system;
 the values must be present at build time.
+
+This app can be deployed to Netlify:
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/PhilanthropyDataCommons/front-end)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The environment variables documented in `.env.example`
 will need to be configured in your deployment system;
 the values must be present at build time.
 
-This app can be deployed to Netlify:
+This app can be deployed to multiple platform services:
 
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/PhilanthropyDataCommons/front-end/tree/main)
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/PhilanthropyDataCommons/front-end)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "https://pilot.philanthropydatacommons.org/*"
+  to = "https://app.philanthropydatacommons.org/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+[template.environment]
+  VITE_API_URL = "https://api.example.com"
+  VITE_OIDC_AUTHORITY = "https://auth.example.com/realms/example"
+  VITE_OIDC_CLIENT_ID = "example-front-end"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,0 @@
-# https://docs.netlify.com/routing/redirects/
-
-# Move from pilot.pdco to app.pdco
-https://pilot.philanthropydatacommons.org/* https://app.philanthropydatacommons.org/:splat 301!
-
-/*  /index.html  200

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -136,7 +136,7 @@ const AppNavbar = () => {
 								</DropdownMenuLinkDescription>
 							</DropdownMenuLink>
 							{import.meta.env.VITE_SHOW_STORYBOOK === 'true' && (
-								<DropdownMenuLink to="/storybook" reloadDocument>
+								<DropdownMenuLink to="/storybook/" reloadDocument>
 									Storybook
 									<DropdownMenuLinkDescription>
 										View our UI component library. (Only relevant to PDC front


### PR DESCRIPTION
In order to deploy to DigitalOcean App Platform, we need to make one adjustment to the code, and add some documentation.

Since this is currently deployed to Netlify, it seems to be about time to add a "Deploy to Netlify" button, and then a "Deploy to DigitalOcean" button next to it. (I wish they were the same size, but not sure how to do that in markdown.)

Issue PhilanthropyDataCommons/deploy#118 Migrate to DigitalOcean Apps