### PR TITLE
Vite cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,47 +35,10 @@ Copy the `.env.example` file to `.env.local`,
 and replace the placeholder values with your specifics.
 Your new `.env.local` file will not be picked up by git.
 
-Then run `npm start` (see [that script's documentation](#npm-start) for further details).
+Then run `npm start`.
 
 ### Production
 
 The environment variables documented in `.env.example`
 will need to be configured in your deployment system;
 the values must be present at build time.
-
-## Available Scripts
-
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,6 @@
 				"web-vitals": "^4.0.1"
 			},
 			"devDependencies": {
-				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-				"@babel/preset-typescript": "^7.24.7",
 				"@storybook/addon-essentials": "^8.3.4",
 				"@storybook/addon-interactions": "^8.3.4",
 				"@storybook/addon-links": "^8.3.4",
@@ -40,7 +38,6 @@
 				"@typescript-eslint/eslint-plugin": "^7.17.0",
 				"@typescript-eslint/parser": "^7.17.0",
 				"@vitejs/plugin-react": "^4.3.2",
-				"babel-plugin-named-exports-order": "^0.0.2",
 				"eslint": "^v8.57.1",
 				"eslint-config-airbnb": "^19.0.4",
 				"eslint-config-airbnb-typescript": "^18.0.0",
@@ -168,18 +165,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-			"integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.25.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
@@ -191,40 +176,6 @@
 				"browserslist": "^4.23.1",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
-			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-member-expression-to-functions": "^7.24.8",
-				"@babel/helper-optimise-call-expression": "^7.24.7",
-				"@babel/helper-replace-supers": "^7.25.0",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/traverse": "^7.25.4",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
-			"integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/traverse": "^7.24.8",
-				"@babel/types": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -261,18 +212,6 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
-			"integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-plugin-utils": {
 			"version": "7.24.8",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
@@ -282,40 +221,10 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
-			"integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.24.8",
-				"@babel/helper-optimise-call-expression": "^7.24.7",
-				"@babel/traverse": "^7.25.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
 		"node_modules/@babel/helper-simple-access": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
 			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/traverse": "^7.24.7",
-				"@babel/types": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
-			"integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.24.7",
@@ -395,87 +304,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.21.11",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-			"integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.18.6",
-				"@babel/helper-create-class-features-plugin": "^7.21.0",
-				"@babel/helper-plugin-utils": "^7.20.2",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-			"integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.25.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
-			"integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.8"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
-			"integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.24.8",
-				"@babel/helper-plugin-utils": "^7.24.8",
-				"@babel/helper-simple-access": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/plugin-transform-react-jsx-self": {
 			"version": "7.24.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.7.tgz",
@@ -498,44 +326,6 @@
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
-			"integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.24.7",
-				"@babel/helper-create-class-features-plugin": "^7.25.0",
-				"@babel/helper-plugin-utils": "^7.24.8",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-				"@babel/plugin-syntax-typescript": "^7.24.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/preset-typescript": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
-			"integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.24.7",
-				"@babel/helper-validator-option": "^7.24.7",
-				"@babel/plugin-syntax-jsx": "^7.24.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.24.7",
-				"@babel/plugin-transform-typescript": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3424,12 +3214,6 @@
 			"dependencies": {
 				"deep-equal": "^2.0.5"
 			}
-		},
-		"node_modules/babel-plugin-named-exports-order": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-named-exports-order/-/babel-plugin-named-exports-order-0.0.2.tgz",
-			"integrity": "sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==",
-			"dev": true
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
 		"web-vitals": "^4.0.1"
 	},
 	"devDependencies": {
-		"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-		"@babel/preset-typescript": "^7.24.7",
 		"@storybook/addon-essentials": "^8.3.4",
 		"@storybook/addon-interactions": "^8.3.4",
 		"@storybook/addon-links": "^8.3.4",
@@ -35,7 +33,6 @@
 		"@typescript-eslint/eslint-plugin": "^7.17.0",
 		"@typescript-eslint/parser": "^7.17.0",
 		"@vitejs/plugin-react": "^4.3.2",
-		"babel-plugin-named-exports-order": "^0.0.2",
 		"eslint": "^v8.57.1",
 		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-airbnb-typescript": "^18.0.0",


### PR DESCRIPTION
Clean up the README and a few dependencies left over from create-react-app.

PR #856 Bump @babel/preset-typescript from 7.24.7 to 7.25.7
Follow-up to PR #748 Migrate to Vite
Issue #720 Move To Vite