### PR TITLE
Add source label to proposal version

### DIFF
--- a/src/components/ChangemakerProposal/ChangemakerProposalLoader.tsx
+++ b/src/components/ChangemakerProposal/ChangemakerProposalLoader.tsx
@@ -31,11 +31,13 @@ const ChangemakerProposalLoader = ({
 				version={0}
 				values={[]}
 				onClose={onClose}
+				source={undefined}
 			/>
 		);
 	}
 
 	const version = proposal.versions[0]?.version ?? 0;
+	const source = proposal.versions[0]?.source?.label ?? undefined;
 	const values = mapProposalBaseFields(baseFields, proposal);
 	const title = getTitle(baseFields, proposal);
 
@@ -44,6 +46,7 @@ const ChangemakerProposalLoader = ({
 			proposalId={proposalId}
 			version={version}
 			values={values}
+			source={source}
 			onClose={onClose}
 			title={title}
 		/>

--- a/src/components/ChangemakerProposal/ChangemakerProposalPanel.tsx
+++ b/src/components/ChangemakerProposal/ChangemakerProposalPanel.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ArrowsPointingOutIcon } from '@heroicons/react/24/solid';
-import { ClosablePanel, PanelTitle } from '../Panel';
+import { ClosablePanel, PanelTag, PanelTitle } from '../Panel';
 import { ProposalTable } from '../ProposalTable';
 import { Button } from '../Button';
 
@@ -35,6 +35,7 @@ interface ChangemakerProposalPanelProps {
 		position: number;
 		value: string;
 	}[];
+	source: string | undefined;
 	onClose: () => void;
 	title?: string;
 }
@@ -43,6 +44,7 @@ const ChangemakerProposalPanel = ({
 	proposalId,
 	version,
 	values,
+	source,
 	onClose,
 	title = 'Untitled Proposal',
 }: ChangemakerProposalPanelProps) => (
@@ -51,6 +53,7 @@ const ChangemakerProposalPanel = ({
 		onClose={onClose}
 		padded={false}
 		actions={<ChangemakerProposalPanelActions proposalId={proposalId} />}
+		tags={source ? <PanelTag badge="Source">{source}</PanelTag> : undefined}
 	>
 		<ProposalTable version={version} values={values} />
 	</ClosablePanel>

--- a/src/components/Panel/ClosablePanel.tsx
+++ b/src/components/Panel/ClosablePanel.tsx
@@ -5,12 +5,14 @@ import { Panel } from './Panel';
 import { PanelHeader } from './PanelHeader';
 import { PanelActions } from './PanelActions';
 import { PanelTitleWrapper } from './PanelTitleWrapper';
+import { PanelTitleTags } from './PanelTitleTags';
 import { PanelBody } from './PanelBody';
 
 interface ClosablePanelProps {
 	children: React.ReactNode;
 	onClose: () => void;
 	title: React.ReactNode;
+	tags?: React.ReactNode;
 	/**
 	 * Controls whether the panel body has internal padding.
 	 */
@@ -22,12 +24,14 @@ const ClosablePanel = ({
 	children,
 	onClose,
 	title,
+	tags = undefined,
 	padded = true,
 	actions = undefined,
 }: ClosablePanelProps) => (
 	<Panel>
 		<PanelHeader>
 			<PanelTitleWrapper>{title}</PanelTitleWrapper>
+			{tags && <PanelTitleTags> {tags} </PanelTitleTags>}
 			<PanelActions>
 				{actions}
 				<Button onClick={onClose} color="red" title="Close this panel">

--- a/src/components/ProposalDetailPanel.tsx
+++ b/src/components/ProposalDetailPanel.tsx
@@ -21,6 +21,7 @@ interface ProposalDetailPanelProps {
 		position: number;
 		value: string;
 	}[];
+	source: string | undefined;
 }
 
 const ProposalDetailPanel = ({
@@ -29,6 +30,7 @@ const ProposalDetailPanel = ({
 	applicantId,
 	version,
 	values,
+	source,
 }: ProposalDetailPanelProps) => (
 	<Panel>
 		<PanelHeader>
@@ -39,6 +41,7 @@ const ProposalDetailPanel = ({
 						<PanelTag icon={<BuildingOffice2Icon />}>{applicant}</PanelTag>
 					)}
 					{applicantId && <PanelTag badge="Tax ID">{applicantId}</PanelTag>}
+					{source && <PanelTag badge="Source">{source}</PanelTag>}
 				</PanelTitleTags>
 			</PanelTitleWrapper>
 		</PanelHeader>

--- a/src/pages/ProposalDetail.tsx
+++ b/src/pages/ProposalDetail.tsx
@@ -98,6 +98,7 @@ const ProposalDetailPanelLoader = ({
 					applicantId="00-0000000"
 					version={0}
 					values={[]}
+					source={undefined}
 				/>
 			</PanelGridItem>
 		);
@@ -112,6 +113,7 @@ const ProposalDetailPanelLoader = ({
 	);
 	const version = proposal.versions[0]?.version ?? 0;
 	const values = mapProposalBaseFields(baseFields, proposal);
+	const source = proposal.versions[0]?.source?.label ?? undefined;
 
 	return (
 		<PanelGridItem key="detailPanel">
@@ -121,6 +123,7 @@ const ProposalDetailPanelLoader = ({
 				applicantId={applicantId}
 				version={version}
 				values={values}
+				source={source}
 			/>
 		</PanelGridItem>
 	);

--- a/src/stories/ProposalDetail.stories.tsx
+++ b/src/stories/ProposalDetail.stories.tsx
@@ -25,5 +25,6 @@ export const Default: Story = {
 				value: '2023-01-20',
 			},
 		],
+		source: 'Philanthropy Data Commons',
 	},
 };


### PR DESCRIPTION
This commit adds the rendering for a given proposal version's Source, following the same pattern as we currently use for applicant and tax ID (the Panel Tag component).

Closes #913 