### PR TITLE
Group react more aggressively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,7 @@ updates:
           - '@storybook/*'
       react:
         patterns:
-          - 'react'
-          - 'react-dom'
-          - '@types/react'
-          - '@types/react-dom'
+          - '*react*'
       eslint:
         patterns:
           - '*eslint*'


### PR DESCRIPTION
This PR groups react dependencies in dependabot more aggressively, which addresses the broken dependabot PRs we're seeing right now.