### PR TITLE
Move configuration out of package.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,49 @@
+{
+	"extends": [
+		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/recommended-requiring-type-checking",
+		"plugin:@typescript-eslint/strict",
+		"plugin:vue/vue3-recommended",
+		"@vue/eslint-config-airbnb-with-typescript",
+		"prettier",
+		"plugin:storybook/recommended"
+	],
+	"parserOptions": {
+		"parser": "@typescript-eslint/parser",
+		"project": "./tsconfig.json",
+		"extraFileExtensions": [".vue"],
+		"ecmaVersion": 2022,
+		"sourceType": "module"
+	},
+	"ignorePatterns": [
+		"vite.config.js",
+		"public/OidcServiceWorker.js",
+		"public/OidcTrustedDomains.js",
+		"build",
+		"dist"
+	],
+	"rules": {
+		"import/prefer-default-export": "off",
+		"import/no-default-export": "error",
+		"import/no-extraneous-dependencies": [
+			"error",
+			{
+				"devDependencies": [
+					"**/*.test.{ts,tsx}",
+					"src/setupTests.ts",
+					"**/*.stories.*"
+				],
+				"optionalDependencies": false
+			}
+		]
+	},
+	"overrides": [
+		{
+			"files": ["**/*.stories.*"],
+			"rules": {
+				"import/no-anonymous-default-export": "off",
+				"import/no-default-export": "off"
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -59,59 +59,6 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build"
 	},
-	"eslintConfig": {
-		"extends": [
-			"plugin:@typescript-eslint/recommended",
-			"plugin:@typescript-eslint/recommended-requiring-type-checking",
-			"plugin:@typescript-eslint/strict",
-			"plugin:vue/vue3-recommended",
-			"@vue/eslint-config-airbnb-with-typescript",
-			"prettier",
-			"plugin:storybook/recommended"
-		],
-		"parserOptions": {
-			"parser": "@typescript-eslint/parser",
-			"project": "./tsconfig.json",
-			"extraFileExtensions": [
-				".vue"
-			],
-			"ecmaVersion": 2022,
-			"sourceType": "module"
-		},
-		"ignorePatterns": [
-			"vite.config.js",
-			"public/OidcServiceWorker.js",
-			"public/OidcTrustedDomains.js",
-			"build",
-			"dist"
-		],
-		"rules": {
-			"import/prefer-default-export": "off",
-			"import/no-default-export": "error",
-			"import/no-extraneous-dependencies": [
-				"error",
-				{
-					"devDependencies": [
-						"**/*.test.{ts,tsx}",
-						"src/setupTests.ts",
-						"**/*.stories.*"
-					],
-					"optionalDependencies": false
-				}
-			]
-		},
-		"overrides": [
-			{
-				"files": [
-					"**/*.stories.*"
-				],
-				"rules": {
-					"import/no-anonymous-default-export": "off",
-					"import/no-default-export": "off"
-				}
-			}
-		]
-	},
 	"browserslist": {
 		"production": [
 			">0.2%",


### PR DESCRIPTION
This commit separates the eslintConfig into it's own file, which has been our preferred method of configuration in the PDC service repository for over a year. Furthermore, this will more elegantly support our move to eslint9, which expects a flat configuration file by default.

Closs #994 