### PR TITLE
Re-enable love rules

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -4,7 +4,7 @@ interface ImportMetaEnv {
 	readonly VITE_KEYCLOAK_CLIENT_ID: string;
 	readonly VITE_KEYCLOAK_REALM: string;
 	readonly VITE_API_URL: string;
-	readonly VITE_LOG_LEVEL: string;
+	readonly VITE_LOG_LEVEL?: string;
 }
 
 interface ImportMeta {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/no-unsafe-type-assertion': 'off',
 			'@typescript-eslint/strict-boolean-expressions': 'off',
 			'@typescript-eslint/switch-exhaustiveness-check': 'off',
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,11 +48,6 @@ export default typescriptEslint.config(
 		},
 	},
 	{
-		rules: {
-			'@typescript-eslint/no-confusing-void-expression': 'off',
-		},
-	},
-	{
 		files: ['**/*.stories.*'],
 		rules: {
 			'import/no-anonymous-default-export': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-type-assertion': 'off',
 			'@typescript-eslint/strict-boolean-expressions': 'off',
 			'@typescript-eslint/switch-exhaustiveness-check': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			'@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
 			'@typescript-eslint/prefer-destructuring': 'off',
 			'@typescript-eslint/no-unnecessary-type-parameters': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/strict-boolean-expressions': 'off',
 			'@typescript-eslint/switch-exhaustiveness-check': 'off',
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			'@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/switch-exhaustiveness-check': 'off',
 			'@typescript-eslint/prefer-nullish-coalescing': 'off',
 			'@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
 			'@typescript-eslint/prefer-destructuring': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/no-unnecessary-type-parameters': 'off',
 			'@typescript-eslint/no-confusing-void-expression': 'off',
 		},
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
 			'@typescript-eslint/prefer-destructuring': 'off',
 			'@typescript-eslint/no-unnecessary-type-parameters': 'off',
 			'@typescript-eslint/no-confusing-void-expression': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/explicit-function-return-type': 'off',
 			'@typescript-eslint/no-unnecessary-condition': 'off',
 			'@typescript-eslint/no-unsafe-type-assertion': 'off',
 			'@typescript-eslint/strict-boolean-expressions': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,7 +49,6 @@ export default typescriptEslint.config(
 	},
 	{
 		rules: {
-			'@typescript-eslint/prefer-destructuring': 'off',
 			'@typescript-eslint/no-unnecessary-type-parameters': 'off',
 			'@typescript-eslint/no-confusing-void-expression': 'off',
 		},

--- a/src/components/AppBanner.vue
+++ b/src/components/AppBanner.vue
@@ -12,7 +12,7 @@ const route = useRoute();
 const isHomePage = route.path === '/';
 const showBanner = !authenticated && !isHomePage;
 
-const handleLogin = async () => {
+const handleLogin = async (): Promise<void> => {
 	await loginFn?.()?.catch(logger.error);
 };
 </script>

--- a/src/components/AppBanner.vue
+++ b/src/components/AppBanner.vue
@@ -13,7 +13,7 @@ const isHomePage = route.path === '/';
 const showBanner = !authenticated && !isHomePage;
 
 const handleLogin = async (): Promise<void> => {
-	await loginFn?.()?.catch(logger.error);
+	await loginFn?.().catch(logger.error);
 };
 </script>
 

--- a/src/components/CustomButton.vue
+++ b/src/components/CustomButton.vue
@@ -66,9 +66,7 @@ if (linkStyle) {
 	buttonClassNames.push('button--link-style');
 }
 
-if (className !== undefined) {
-	buttonClassNames.push(className);
-}
+buttonClassNames.push(className);
 </script>
 
 <template>

--- a/src/components/Dropdown/DropdownMenuButton.vue
+++ b/src/components/Dropdown/DropdownMenuButton.vue
@@ -27,7 +27,7 @@ const handleClick = (e: MouseEvent): void => {
 		target.closest('.dropdown')?.removeAttribute('open');
 	}
 
-	if (onClick) {
+	if (onClick !== undefined) {
 		onClick();
 	}
 };

--- a/src/components/Dropdown/DropdownMenuButton.vue
+++ b/src/components/Dropdown/DropdownMenuButton.vue
@@ -21,7 +21,7 @@ const {
 	onClick = undefined,
 } = defineProps<DropdownMenuButtonProps>();
 
-const handleClick = (e: Event) => {
+const handleClick = (e: Event): void => {
 	const $target = e.target as HTMLLinkElement;
 	$target.closest('.dropdown')?.removeAttribute('open');
 

--- a/src/components/Dropdown/DropdownMenuButton.vue
+++ b/src/components/Dropdown/DropdownMenuButton.vue
@@ -21,9 +21,11 @@ const {
 	onClick = undefined,
 } = defineProps<DropdownMenuButtonProps>();
 
-const handleClick = (e: Event): void => {
-	const $target = e.target as HTMLLinkElement;
-	$target.closest('.dropdown')?.removeAttribute('open');
+const handleClick = (e: MouseEvent): void => {
+	const { target } = e;
+	if (target instanceof HTMLElement) {
+		target.closest('.dropdown')?.removeAttribute('open');
+	}
 
 	if (onClick) {
 		onClick();

--- a/src/components/Dropdown/DropdownMenuLink.vue
+++ b/src/components/Dropdown/DropdownMenuLink.vue
@@ -29,7 +29,7 @@ const {
 	className = '',
 } = defineProps<DropdownMenuLinkProps>();
 
-const handleClick = (e: Event) => {
+const handleClick = (e: Event): void => {
 	const $target = e.target as HTMLLinkElement;
 	$target.closest('.dropdown')?.removeAttribute('open');
 };

--- a/src/components/Dropdown/DropdownMenuLink.vue
+++ b/src/components/Dropdown/DropdownMenuLink.vue
@@ -29,9 +29,11 @@ const {
 	className = '',
 } = defineProps<DropdownMenuLinkProps>();
 
-const handleClick = (e: Event): void => {
-	const $target = e.target as HTMLLinkElement;
-	$target.closest('.dropdown')?.removeAttribute('open');
+const handleClick = (e: MouseEvent): void => {
+	const { target } = e;
+	if (target instanceof HTMLElement) {
+		target.closest('.dropdown')?.removeAttribute('open');
+	}
 };
 </script>
 

--- a/src/components/Dropdown/DropdownTrigger.vue
+++ b/src/components/Dropdown/DropdownTrigger.vue
@@ -14,7 +14,6 @@ switch (type) {
 	case 'button':
 		typeClassName = 'button button--bordered';
 		break;
-	default:
 }
 </script>
 

--- a/src/components/EmailLink.vue
+++ b/src/components/EmailLink.vue
@@ -23,15 +23,15 @@ const {
 } = defineProps<EmailLinkProps>();
 
 let params = '';
-if (subject || body) {
+if (subject !== undefined || body !== undefined) {
 	const paramObj: {
 		subject?: string;
 		body?: string;
 	} = {};
-	if (subject) {
+	if (subject !== undefined) {
 		paramObj.subject = subject;
 	}
-	if (body) {
+	if (body !== undefined) {
 		paramObj.body = body;
 	}
 

--- a/src/components/UserComponent.vue
+++ b/src/components/UserComponent.vue
@@ -17,11 +17,11 @@ const logger = getLogger('<UserComponent>');
 
 const { authenticated, login, logoutFn, userName } = useKeycloak();
 
-const handleLogin = async () => {
+const handleLogin = async (): Promise<void> => {
 	await login?.().catch(logger.error);
 };
 
-const handleLogout = async () => {
+const handleLogout = async (): Promise<void> => {
 	await logoutFn?.()?.catch(logger.error);
 };
 </script>

--- a/src/keycloakConfig.ts
+++ b/src/keycloakConfig.ts
@@ -10,15 +10,15 @@ const getOptions = (
 	clientId?: string,
 	realm?: string,
 ): VueKeycloakConfig => {
-	if (!authority) {
+	if (authority == null) {
 		throw new Error('No Keycloak authority configured');
 	}
 
-	if (!clientId) {
+	if (clientId == null) {
 		throw new Error('No Keycloak client ID configured');
 	}
 
-	if (!realm) {
+	if (realm == null) {
 		throw new Error('No Keycloak realm configured');
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ logger.debug(keycloakOptions, 'Keycloak options');
 			app.use(initRouter()).mount('#app');
 		},
 	});
-})().catch((error) => {
+})().catch((error: unknown) => {
 	logger.error('error initializing application', error);
 });
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -1,24 +1,28 @@
 import { ref, onMounted, watch } from 'vue';
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
-import type { BaseField } from '@pdc/sdk';
 import { getLogger } from '@/logger';
+import type { Ref } from 'vue';
+import type { BaseField } from '@pdc/sdk';
 
 const logger = getLogger('pdc-api');
 const API_URL = import.meta.env.VITE_API_URL;
 
 const { token } = useKeycloak();
 
-function throwIfNotOk(res: Response) {
+function throwIfNotOk(res: Response): Response {
 	if (!res.ok) {
 		throw new Error(`Response status: ${res.status} ${res.statusText}`);
 	}
 	return res;
 }
 
-export function usePdcApi<T>(path: string, params = new URLSearchParams()) {
-	const data = ref<T | null>(null);
+export function usePdcApi<T>(
+	path: string,
+	params = new URLSearchParams(),
+): { data: Ref<T | null>; fetchData: () => Promise<void> } {
+	const data: Ref<T | null> = ref(null);
 
-	const fetchData = async () => {
+	const fetchData = async (): Promise<void> => {
 		data.value = null;
 		try {
 			const url = new URL(path, API_URL);
@@ -44,6 +48,6 @@ export function usePdcApi<T>(path: string, params = new URLSearchParams()) {
 	return { data, fetchData };
 }
 
-export function useBaseFields() {
+export function useBaseFields(): ReturnType<typeof usePdcApi<BaseField[]>> {
 	return usePdcApi<BaseField[]>('/baseFields');
 }

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -5,7 +5,9 @@ import type { Ref } from 'vue';
 import type { BaseField } from '@pdc/sdk';
 
 const logger = getLogger('pdc-api');
-const API_URL = import.meta.env.VITE_API_URL;
+const {
+	env: { VITE_API_URL: API_URL },
+} = import.meta;
 
 const { token } = useKeycloak();
 

--- a/src/pdc-api.ts
+++ b/src/pdc-api.ts
@@ -31,7 +31,10 @@ export function usePdcApi<T>(
 			const res = await fetch(url.toString(), {
 				headers: { Authorization: `Bearer ${token}` },
 			}).then(throwIfNotOk);
-
+			/*  eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion --
+			 * We are assuming here that the pdc-service being communicated with is functioning
+			 * correctly, such that if the request is successful, the response is valid JSON of the
+			 */
 			data.value = (await res.json()) as T;
 		} catch (err) {
 			logger.error(

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -5,8 +5,9 @@ import { getLogger } from './logger';
 
 const reportWebVitals = (): void => {
 	const logger = getLogger('web-vitals');
-	const reportHandler: (metric: Metric) => void = (metric: Metric) =>
+	const reportHandler: (metric: Metric) => void = (metric: Metric) => {
 		logger.info(metric);
+	};
 	onCLS(reportHandler);
 	onFCP(reportHandler);
 	onINP(reportHandler);

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -3,7 +3,7 @@ import type { Metric } from 'web-vitals';
 
 import { getLogger } from './logger';
 
-const reportWebVitals = () => {
+const reportWebVitals = (): void => {
 	const logger = getLogger('web-vitals');
 	const reportHandler: (metric: Metric) => void = (metric: Metric) =>
 		logger.info(metric);

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,14 @@
 import { createWebHistory, createRouter } from 'vue-router';
 import LandingView from '@/views/LandingView.vue';
 import NotFoundView from '@/views/NotFoundView.vue';
+import type { Router } from 'vue-router';
 
 const routes = [
 	{ path: '/', component: LandingView },
 	{ path: '/:pathMatch(.*)', component: NotFoundView },
 ];
 
-const initRouter = () =>
+const initRouter = (): Router =>
 	createRouter({
 		history: createWebHistory(),
 		routes,

--- a/src/utils/baseFields.ts
+++ b/src/utils/baseFields.ts
@@ -5,7 +5,7 @@ import type { BaseField } from '@pdc/sdk';
  * @param  {BaseField[]} fields an array of BaseFields
  * @return {Record<string,string>} a map between basefield shortcodes and labels
  */
-const mapFieldNames = (fields: BaseField[]) =>
+const mapFieldNames = (fields: BaseField[]): Record<string, string> =>
 	Object.fromEntries(fields.map(({ label, shortCode }) => [shortCode, label]));
 
 export { mapFieldNames };

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -13,7 +13,7 @@ dayjs.extend(relativeTime);
  * @param  {Date | string} timestamp Date object or string
  * @return {string} Input datetime, expressed relative to now
  */
-const relativizeDateTime = (timestamp: Date | string) =>
+const relativizeDateTime = (timestamp: Date | string): string =>
 	dayjs().to(dayjs(timestamp));
 
 /**
@@ -28,7 +28,7 @@ const relativizeDateTime = (timestamp: Date | string) =>
  * @param  {string} format DayJS format code (see docs)
  * @return {string} Liocal version of datetime in our preferred format
  */
-const localizeDateTime = (timestamp: Date | string, format = 'LLL') =>
+const localizeDateTime = (timestamp: Date | string, format = 'LLL'): string =>
 	dayjs(timestamp).format(format);
 
 export { localizeDateTime, relativizeDateTime };

--- a/src/views/LandingView.vue
+++ b/src/views/LandingView.vue
@@ -12,7 +12,7 @@ const logger = getLogger('<LandingView>');
 
 const { authenticated, login } = useKeycloak();
 
-const handleLogin = async () => {
+const handleLogin = async (): Promise<void> => {
 	await login?.().catch(logger.error);
 };
 </script>


### PR DESCRIPTION
This PR re-enables all the rules that we disabled on introduction of the love ESLint config, linting the codebase commit by commit. 
[ Re-enable @typescript-eslint/no-unnecessary-type-parameters](https://github.com/PhilanthropyDataCommons/front-end/commit/b62708f8e091cdb443b5762b616ba2e1e26f5331) includes a large write up, mostly detailing this info for 'if this comes up again' purposes. It's a small change but took a long time to resolve/understand what was going on under the hood better. It also brought up to me that I may want to rethink/research the proper data fetching/re-fetching patterns in vue for this function and future functions.

Closes #1056 