### PR TITLE
Make SidePanel sticky

### DIFF
--- a/apps/admin-interface/src/App.vue
+++ b/apps/admin-interface/src/App.vue
@@ -37,10 +37,9 @@ const navLinks = [
 }
 
 .App {
-	position: absolute;
+	position: relative;
 	inset: 0;
 	display: flex;
-	height: 100vh;
 }
 
 .App-main {

--- a/apps/bulk-uploader/src/App.vue
+++ b/apps/bulk-uploader/src/App.vue
@@ -38,10 +38,9 @@ const navLinks = [
 }
 
 .App {
-	position: absolute;
+	position: relative;
 	inset: 0;
 	display: flex;
-	height: 100vh;
 }
 
 .App-main {

--- a/packages/components/src/components/SidePanel.vue
+++ b/packages/components/src/components/SidePanel.vue
@@ -51,10 +51,12 @@ const { navLinks = undefined } = defineProps<SidePanelLinkProps>();
 .side-panel {
 	width: 100%;
 	max-width: 240px;
-	height: 100vh;
 	flex-shrink: 0;
 	display: flex;
 	flex-direction: column;
+	position: sticky;
+	top: 0;
+	height: 100vh;
 	background-color: var(--color--white);
 	padding: var(--fixed-spacing--2x);
 


### PR DESCRIPTION
This commit adds the necessary css to ensure that the sidepanel always occupies the full height of the screen using position:sticky.

Closes #1105 