### PR TITLE
Create table components

### DIFF
--- a/apps/admin-interface/vite.config.ts
+++ b/apps/admin-interface/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
+import path from 'node:path';
 
 export default defineConfig({
 	plugins: [vue()],

--- a/apps/bulk-uploader/vite.config.ts
+++ b/apps/bulk-uploader/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
+import path from 'node:path';
 
 export default defineConfig({
 	plugins: [vue()],

--- a/packages/components/src/components/Table/TableBody.vue
+++ b/packages/components/src/components/Table/TableBody.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+export interface TableBodyProps {
+	className?: string;
+}
+
+const { className = '' } = defineProps<TableBodyProps>();
+</script>
+
+<template>
+	<tbody :class="className">
+		<slot> </slot>
+	</tbody>
+</template>

--- a/packages/components/src/components/Table/TableColumnAction.vue
+++ b/packages/components/src/components/Table/TableColumnAction.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+export interface ColumnActionProps {
+	className?: string;
+	onClick?: () => void;
+}
+
+const { className = '', onClick = () => null } =
+	defineProps<ColumnActionProps>();
+</script>
+
+<template>
+	<button
+		type="button"
+		:class="`column-action ${className}`.trim()"
+		@click="onClick"
+	>
+		<slot> </slot>
+	</button>
+</template>
+
+<style>
+.column-action {
+	all: unset;
+
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.column-action .icon {
+	width: var(--icon-size--text);
+	height: var(--icon-size--text);
+}
+</style>

--- a/packages/components/src/components/Table/TableColumnActions.vue
+++ b/packages/components/src/components/Table/TableColumnActions.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+export interface ColumnActionsProps {
+	className?: string;
+}
+
+const { className = '' } = defineProps<ColumnActionsProps>();
+</script>
+
+<template>
+	<div :class="`column-actions ${className}`.trim()">
+		<slot> </slot>
+	</div>
+</template>
+
+<style>
+.column-actions {
+	display: flex;
+	align-items: center;
+	gap: var(--accessible-spacing--halfx);
+}
+</style>

--- a/packages/components/src/components/Table/TableColumnHead.vue
+++ b/packages/components/src/components/Table/TableColumnHead.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+export interface ColumnHeadProps {
+	className?: string;
+	actions?: boolean;
+}
+
+const { className = '', actions = false } = defineProps<ColumnHeadProps>();
+</script>
+
+<template>
+	<th
+		:class="
+			`
+    ${className}
+    ${actions ? `has-actions ` : ''}
+  `.trim()
+		"
+	>
+		<div class="column-head-wrapper">
+			<slot> </slot>
+		</div>
+	</th>
+</template>
+
+<style scoped>
+th {
+	min-width: 25%;
+	vertical-align: bottom;
+	white-space: nowrap;
+	text-align: left;
+	padding: var(--accessible-spacing--1x);
+	border-bottom: var(--table--border-width) solid var(--color--gray--light);
+}
+
+.has-actions .column-head-wrapper {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: var(--accessible-spacing--1x);
+}
+</style>

--- a/packages/components/src/components/Table/TableComponent.vue
+++ b/packages/components/src/components/Table/TableComponent.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+export interface TableProps {
+	className?: string;
+	/**
+	 * Table body cells won't wrap and will have a max-width,
+	 * above which the text will be hidden.
+	 */
+	truncate?: boolean;
+}
+
+const { className = '', truncate = false } = defineProps<TableProps>();
+</script>
+
+<template>
+	<table
+		:border="0"
+		:cellPadding="0"
+		:cellSpacing="0"
+		:class="`table ${truncate ? 'truncate' : ''} ${className}`.trim()"
+	>
+		<slot> </slot>
+	</table>
+</template>
+
+<style>
+:root {
+	--table--border-width: 1px;
+}
+
+.table {
+	width: 100%;
+}
+
+/* The last column should stretch to the table edge and have no right border. */
+.table th:last-child,
+.table td:last-child {
+	width: 100%;
+	border-right: none;
+}
+
+/* The last body row should have a darker bottom border. */
+.table tbody tr:last-child th,
+.table tbody tr:last-child td {
+	border-bottom: var(--table--border-width) solid var(--color--gray--medium);
+}
+
+/* Truncated tables don't wrap table body contents. */
+.table.truncate tbody td {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 30ch;
+}
+
+.table .clickable {
+	cursor: pointer;
+}
+
+.table .clickable:not(.active):hover {
+	background-color: var(--color--gray--lighter);
+}
+
+.table .active {
+	background-color: var(--color--blue--lighter);
+}
+</style>

--- a/packages/components/src/components/Table/TableHead.vue
+++ b/packages/components/src/components/Table/TableHead.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+export interface TableHeadProps {
+	className?: string;
+	fixed?: boolean;
+}
+
+const { className = '', fixed = false } = defineProps<TableHeadProps>();
+</script>
+
+<template>
+	<thead :class="`${fixed ? 'fixed' : ''} ${className}`.trim()">
+		<slot> </slot>
+	</thead>
+</template>
+
+<style scoped>
+thead {
+	background-color: var(--color--gray--light);
+}
+thead.fixed {
+	position: sticky;
+	top: 0;
+}
+</style>

--- a/packages/components/src/components/Table/TableRow.vue
+++ b/packages/components/src/components/Table/TableRow.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+export interface TableRowProps {
+	className?: string;
+	onClick?: () => void;
+	active?: boolean;
+}
+
+const {
+	className = '',
+	onClick = undefined,
+	active = false,
+} = defineProps<TableRowProps>();
+</script>
+
+<template>
+	<tr
+		:class="
+			`${className} ${onClick ? 'clickable' : ''} ${active ? 'active' : ''}`.trim()
+		"
+		@click="onClick"
+	>
+		<slot> </slot>
+	</tr>
+</template>

--- a/packages/components/src/components/Table/TableRowCell.vue
+++ b/packages/components/src/components/Table/TableRowCell.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+export interface RowCellProps {
+	className?: string;
+}
+
+const { className = '' } = defineProps<RowCellProps>();
+</script>
+
+<template>
+	<td :class="` ${className}`.trim()">
+		<slot> </slot>
+	</td>
+</template>
+<style scoped>
+td {
+	vertical-align: top;
+	padding: var(--accessible-spacing--1x);
+	border-bottom: var(--table--border-width) solid var(--color--gray--light);
+}
+</style>

--- a/packages/components/src/components/Table/index.ts
+++ b/packages/components/src/components/Table/index.ts
@@ -1,0 +1,19 @@
+import TableComponent from './TableComponent.vue';
+import TableHead from './TableHead.vue';
+import TableColumnHead from './TableColumnHead.vue';
+import TableColumnActions from './TableColumnActions.vue';
+import TableColumnAction from './TableColumnAction.vue';
+import TableBody from './TableBody.vue';
+import TableRow from './TableRow.vue';
+import TableRowCell from './TableRowCell.vue';
+
+export {
+	TableComponent,
+	TableHead,
+	TableColumnHead,
+	TableColumnActions,
+	TableColumnAction,
+	TableBody,
+	TableRow,
+	TableRowCell,
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -21,3 +21,14 @@ export {
 	PanelHeaderAction,
 	PanelHeaderActionsWrapper,
 } from './components/Panel';
+
+export {
+	TableColumnAction,
+	TableColumnActions,
+	TableColumnHead,
+	TableRowCell,
+	TableBody,
+	TableComponent,
+	TableHead,
+	TableRow,
+} from './components/Table';

--- a/packages/components/src/stories/TableComponent.stories.ts
+++ b/packages/components/src/stories/TableComponent.stories.ts
@@ -1,0 +1,296 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { BaseField } from '@pdc/sdk';
+import {
+	TableComponent,
+	TableHead,
+	TableBody,
+	TableRow,
+	TableRowCell,
+	TableColumnHead,
+} from '../components/Table';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+} from '../components/Panel';
+import {
+	DocumentPlusIcon,
+	AdjustmentsHorizontalIcon,
+} from '@heroicons/vue/24/outline';
+
+const meta = {
+	component: TableComponent,
+	tags: ['autodocs'],
+} satisfies Meta<typeof TableComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const valueRelevanceHoursDefault = 0;
+
+const sampleBaseFields: BaseField[] = [
+	{
+		shortCode: 'org_name',
+		label: 'Organization Name',
+		description: 'The name of the organization',
+		dataType: BaseField.DataTypeEnum.String,
+		category: BaseField.CategoryEnum.Organization,
+		valueRelevanceHours: valueRelevanceHoursDefault,
+		sensitivityClassification: BaseField.SensitivityClassificationEnum.Public,
+		createdAt: '2025-01-01T00:00:00Z',
+	},
+	{
+		shortCode: 'ein',
+		label: 'EIN',
+		description: 'Tax identification number',
+		dataType: BaseField.DataTypeEnum.String,
+		category: BaseField.CategoryEnum.Organization,
+		valueRelevanceHours: valueRelevanceHoursDefault,
+		sensitivityClassification:
+			BaseField.SensitivityClassificationEnum.Restricted,
+		createdAt: '2025-01-01T00:00:00Z',
+	},
+	{
+		shortCode: 'org_email',
+		label: 'Organization Email',
+		description: 'The email of the organization',
+		dataType: BaseField.DataTypeEnum.String,
+		category: BaseField.CategoryEnum.Organization,
+		valueRelevanceHours: valueRelevanceHoursDefault,
+		sensitivityClassification: BaseField.SensitivityClassificationEnum.Public,
+		createdAt: '2025-01-01T00:00:00Z',
+	},
+	{
+		shortCode: 'org_phone',
+		label: 'Organization Phone',
+		description: 'The phone number of the organization',
+		dataType: BaseField.DataTypeEnum.String,
+		category: BaseField.CategoryEnum.Organization,
+		valueRelevanceHours: valueRelevanceHoursDefault,
+		sensitivityClassification: BaseField.SensitivityClassificationEnum.Public,
+		createdAt: '2025-01-01T00:00:00Z',
+	},
+];
+
+export const Default: Story = {
+	render: (args) => ({
+		components: {
+			TableComponent,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			TableHead,
+			TableBody,
+			TableRow,
+			TableColumnHead,
+			TableRowCell,
+			DocumentPlusIcon,
+		},
+		setup() {
+			return { args, baseFields: sampleBaseFields };
+		},
+		template: `<PanelComponent>
+		<PanelHeader>
+			<h1>Base Fields</h1>
+			<PanelHeaderActionsWrapper class="disabled">
+				<PanelHeaderAction>
+					<DocumentPlusIcon class="icon" />
+					<p class="download-csv-text">Download CSV template</p>
+				</PanelHeaderAction>
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody :padded="false">
+			<TableComponent
+
+			>
+				<TableHead fixed>
+					<TableRow>
+						<TableColumnHead>Label</TableColumnHead>
+						<TableColumnHead>Description</TableColumnHead>
+						<TableColumnHead>Short code</TableColumnHead>
+						<TableColumnHead>Data type</TableColumnHead>
+						<TableColumnHead>Category</TableColumnHead>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow v-for="field in baseFields" :key="field.shortCode">
+						<TableRowCell>{{ field.label }}</TableRowCell>
+						<TableRowCell>{{ field.description }}</TableRowCell>
+						<TableRowCell>{{ field.shortCode }}</TableRowCell>
+						<TableRowCell>{{ field.dataType }}</TableRowCell>
+						<TableRowCell>{{ field.category }}</TableRowCell>
+					</TableRow>
+				</TableBody>
+			</TableComponent>
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};
+
+export const TruncatedTable: Story = {
+	render: (args) => ({
+		components: {
+			TableComponent,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			TableHead,
+			TableBody,
+			TableRow,
+			TableColumnHead,
+			TableRowCell,
+			DocumentPlusIcon,
+		},
+		setup() {
+			return { args, baseFields: sampleBaseFields };
+		},
+		template: `<PanelComponent>
+		<PanelHeader>
+			<h1>Base Fields</h1>
+			<PanelHeaderActionsWrapper class="disabled">
+				<PanelHeaderAction>
+					<DocumentPlusIcon class="icon" />
+					<p class="download-csv-text">Download CSV template</p>
+				</PanelHeaderAction>
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody :padded="false">
+			<TableComponent
+				truncate
+			>
+				<TableHead>
+					<TableRow>
+						<TableColumnHead>Label</TableColumnHead>
+						<TableColumnHead>Description</TableColumnHead>
+						<TableColumnHead>Short code</TableColumnHead>
+						<TableColumnHead>Data type</TableColumnHead>
+						<TableColumnHead>Category</TableColumnHead>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow v-for="field in baseFields" :key="field.shortCode">
+						<TableRowCell>{{ field.label }}</TableRowCell>
+						<TableRowCell>{{ field.description }}</TableRowCell>
+						<TableRowCell>{{ field.shortCode }}</TableRowCell>
+						<TableRowCell>{{ field.dataType }}</TableRowCell>
+						<TableRowCell>{{ field.category }}</TableRowCell>
+					</TableRow>
+				</TableBody>
+			</TableComponent>
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};
+
+export const WithTwoActions: Story = {
+	render: (args) => ({
+		components: {
+			TableComponent,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			TableHead,
+			TableBody,
+			TableRow,
+			TableColumnHead,
+			TableRowCell,
+			DocumentPlusIcon,
+			AdjustmentsHorizontalIcon,
+		},
+		setup() {
+			return { args, baseFields: sampleBaseFields };
+		},
+		template: `<PanelComponent>
+		<PanelHeader>
+			<h1>Base Fields</h1>
+			<PanelHeaderActionsWrapper>
+				<PanelHeaderAction>
+					<DocumentPlusIcon class="icon" />
+					<p class="download-csv-text">Download CSV template</p>
+				</PanelHeaderAction>
+				<PanelHeaderAction>
+					<AdjustmentsHorizontalIcon class="icon" />
+					<p>Add New Base Field</p>
+				</PanelHeaderAction>
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody :padded="false">
+			<TableComponent truncate>
+				<TableHead fixed>
+					<TableRow>
+						<TableColumnHead>Label</TableColumnHead>
+						<TableColumnHead>Description</TableColumnHead>
+						<TableColumnHead>Short code</TableColumnHead>
+						<TableColumnHead>Data type</TableColumnHead>
+						<TableColumnHead>Category</TableColumnHead>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow v-for="field in baseFields" :key="field.shortCode">
+						<TableRowCell>{{ field.label }}</TableRowCell>
+						<TableRowCell>{{ field.description }}</TableRowCell>
+						<TableRowCell>{{ field.shortCode }}</TableRowCell>
+						<TableRowCell>{{ field.dataType }}</TableRowCell>
+						<TableRowCell>{{ field.category }}</TableRowCell>
+					</TableRow>
+				</TableBody>
+			</TableComponent>
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};
+
+export const WithNoActions: Story = {
+	render: (args) => ({
+		components: {
+			TableComponent,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			TableHead,
+			TableBody,
+			TableRow,
+			TableColumnHead,
+			TableRowCell,
+		},
+		setup() {
+			return { args, baseFields: sampleBaseFields };
+		},
+		template: `<PanelComponent>
+		<PanelHeader>
+			<h1>Base Fields</h1>
+		</PanelHeader>
+		<PanelBody :padded="false">
+			<TableComponent truncate>
+				<TableHead fixed>
+					<TableRow>
+						<TableColumnHead>Label</TableColumnHead>
+						<TableColumnHead>Description</TableColumnHead>
+						<TableColumnHead>Short code</TableColumnHead>
+						<TableColumnHead>Data type</TableColumnHead>
+						<TableColumnHead>Category</TableColumnHead>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow v-for="field in baseFields" :key="field.shortCode">
+						<TableRowCell>{{ field.label }}</TableRowCell>
+						<TableRowCell>{{ field.description }}</TableRowCell>
+						<TableRowCell>{{ field.shortCode }}</TableRowCell>
+						<TableRowCell>{{ field.dataType }}</TableRowCell>
+						<TableRowCell>{{ field.category }}</TableRowCell>
+					</TableRow>
+				</TableBody>
+			</TableComponent>
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};


### PR DESCRIPTION
This commit adds a suite of table related components, modeled after the table components that we built in the previous version of this application for rendering data from the pdc in a row/column format. They are intended to be used in both the bulk-uploader and base field admin applications, and are extendable to any data type in the pdc we may wish to render as such.

Column actions are intended to house future logic for sorting and filtering the data in tables. Those will be accomplished in a future commit.

Related to Issue #1068 