### PR TITLE
Implement data input components

### DIFF
--- a/apps/bulk-uploader/src/views/LandingView.vue
+++ b/apps/bulk-uploader/src/views/LandingView.vue
@@ -21,7 +21,7 @@ const handleLogin = async (): Promise<void> => {
 
 <template>
 	<PanelComponent class="landing-panel">
-		<PanelBody>
+		<PanelBody variant="padded">
 			<h3 style="font-weight: 600">Philanthropy Data Commons Bulk Uploader</h3>
 			<p>
 				This site provides tools for uploading data to the Philanthropy Data

--- a/packages/components/src/components/DataInputs/DataSubmitButton.vue
+++ b/packages/components/src/components/DataInputs/DataSubmitButton.vue
@@ -1,0 +1,17 @@
+<template>
+	<div class="data-submit-button">
+		<CustomButton color="blue" inverted submit :disabled="disabled">
+			<slot></slot>
+		</CustomButton>
+	</div>
+</template>
+
+<script setup lang="ts">
+import CustomButton from '../CustomButton.vue';
+export interface DataSubmitButtonProps {
+	disabled?: boolean;
+}
+const { disabled = false } = defineProps<DataSubmitButtonProps>();
+</script>
+
+<style scoped></style>

--- a/packages/components/src/components/DataInputs/FileUploadInput.vue
+++ b/packages/components/src/components/DataInputs/FileUploadInput.vue
@@ -1,0 +1,127 @@
+<template>
+	<div class="file-upload-container">
+		<div class="file-upload-header">
+			<slot class="header" name="file-upload-header"></slot>
+		</div>
+		<label for="file-input" class="file-upload-area">
+			<div v-if="!file" class="upload-text">Select a file to upload</div>
+			<div v-else class="uploaded-file">
+				<span class="file-name">{{ file.name }}</span>
+				<button class="remove-btn" @click.prevent="removeFile">×</button>
+			</div>
+		</label>
+		<input
+			id="file-input"
+			class="hidden-input"
+			type="file"
+			accept=".csv"
+			@change="handleFileSelect"
+		/>
+		<div class="file-upload-instructions">
+			<slot name="file-upload-instructions"></slot>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+const file = defineModel<File | null>();
+
+const emit = defineEmits<{
+	changed: [file: File | null];
+}>();
+
+const FIRST_FILE_INDEX = 0;
+
+function handleFileSelect(e: Event): void {
+	const { target } = e;
+	if (
+		target instanceof HTMLInputElement &&
+		target.files !== null &&
+		target.files.length > FIRST_FILE_INDEX &&
+		target.files[FIRST_FILE_INDEX] !== undefined
+	) {
+		const { files } = target;
+		const [selectedFile] = files;
+		file.value = selectedFile ?? null;
+		emit('changed', selectedFile ?? null);
+	}
+}
+
+function removeFile(): void {
+	file.value = null;
+	emit('changed', file.value);
+}
+</script>
+
+<style scoped>
+.file-upload-container {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: var(--accessible-spacing--1x);
+}
+
+.file-upload-area {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 120px;
+	padding: var(--accessible-spacing--2x);
+	background-color: var(--color--white);
+	border: 2px solid var(--color--gray--light);
+	border-radius: var(--fixed-spacing--halfx);
+	cursor: pointer;
+	transition:
+		background-color var(--transition-duration--cursor),
+		border-color var(--transition-duration--cursor);
+}
+
+.file-upload-area:hover {
+	background-color: var(--color--gray--lighter);
+	border-color: var(--color--gray--medium-dark);
+}
+
+.upload-text {
+	color: var(--color--gray--medium-dark);
+	font-size: var(--font-size);
+	text-align: center;
+}
+
+.uploaded-file {
+	display: flex;
+	align-items: center;
+	gap: var(--accessible-spacing--1x);
+	width: 100%;
+	justify-content: center;
+	padding: var(--fixed-spacing--1x) var(--accessible-spacing--1x);
+}
+
+.file-name {
+	color: var(--color--gray--dark);
+	font-size: var(--font-size--sm);
+}
+
+.remove-btn {
+	background: none;
+	border: none;
+	color: var(--color--gray--medium);
+	cursor: pointer;
+	font-size: 18px;
+	line-height: 1;
+	padding: 0;
+	width: var(--accessible-spacing--2x);
+	height: var(--accessible-spacing--2x);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: color var(--transition-duration--cursor);
+}
+
+.remove-btn:hover {
+	color: var(--color--gray--medium-dark);
+}
+
+.hidden-input {
+	display: none;
+}
+</style>

--- a/packages/components/src/components/DataInputs/RadioInput.vue
+++ b/packages/components/src/components/DataInputs/RadioInput.vue
@@ -1,0 +1,93 @@
+<template>
+	<div class="radio-input-container">
+		<div class="radio-input-header">
+			<slot class="header" name="radio-input-header"></slot>
+		</div>
+
+		<fieldset>
+			<div
+				v-for="(option, index) in options"
+				:key="option.value"
+				class="radio-input-container"
+			>
+				<div class="radio-input-option">
+					<input
+						:id="`radio-option-${index}-${name}-${option.value}`"
+						v-model="modelValue"
+						type="radio"
+						:name="name"
+						:value="option.value"
+					/>
+					<label :for="`radio-option-${index}-${name}-${option.value}`">{{
+						option.label
+					}}</label>
+				</div>
+				<p v-if="option.description" class="text-color-gray-medium-dark">
+					{{ option.description }}
+				</p>
+			</div>
+		</fieldset>
+		<div class="radio-input-instructions">
+			<slot name="radio-input-instructions"></slot>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+export interface RadioInputProps {
+	options?: Array<{ label: string; value: string; description?: string }>;
+	name?: string;
+}
+
+const modelValue = defineModel<string | null>();
+
+const { options = [], name = 'radio-input' } = defineProps<RadioInputProps>();
+</script>
+
+<style scoped>
+select {
+	margin-top: var(--accessible-spacing--1x);
+
+	border: 2px solid var(--color--gray--light);
+	border-radius: var(--fixed-spacing--halfx);
+	background: white;
+	width: 100%;
+	padding: 10px;
+	transition: 0.4s;
+	font-size: var(--font-size);
+}
+
+select::picker-icon {
+	width: 40px;
+}
+
+fieldset {
+	border: none;
+	padding: 0;
+	margin-top: 10px;
+}
+
+legend {
+	font-size: var(--font-size);
+}
+
+label {
+	font-size: 20px;
+}
+
+.text-color-gray-medium-dark {
+	color: var(--color--gray--medium-dark);
+}
+
+.radio-input-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
+.radio-input-option {
+	display: flex;
+	align-items: center;
+	gap: var(--fixed-spacing--1x);
+}
+</style>

--- a/packages/components/src/components/DataInputs/SelectInput.vue
+++ b/packages/components/src/components/DataInputs/SelectInput.vue
@@ -1,0 +1,51 @@
+<template>
+	<div class="select-input-container">
+		<div class="select-input-header">
+			<slot name="select-input-header"></slot>
+		</div>
+
+		<select v-model="modelValue">
+			<option value=""></option>
+			<option
+				v-for="option in options"
+				:key="option.value"
+				:value="option.value"
+			>
+				{{ option.label }}
+			</option>
+		</select>
+		<div class="select-input-instructions">
+			<slot name="select-input-instructions"></slot>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+const modelValue = defineModel<string | null>();
+export interface SelectInputProps {
+	options?: Array<{ label: string | undefined; value: string | undefined }>;
+}
+const { options = undefined } = defineProps<SelectInputProps>();
+</script>
+
+<style scoped>
+select {
+	margin-top: var(--accessible-spacing--1x);
+
+	border: 2px solid var(--color--gray--light);
+	border-radius: var(--fixed-spacing--halfx);
+	background: white;
+	width: 100%;
+	padding: 10px;
+	transition: 0.4s;
+	font-size: var(--font-size);
+}
+
+select::picker-icon {
+	width: 40px;
+}
+
+.text-color-gray-medium-dark {
+	color: var(--color--gray--medium-dark);
+}
+</style>

--- a/packages/components/src/components/DataInputs/index.ts
+++ b/packages/components/src/components/DataInputs/index.ts
@@ -1,0 +1,6 @@
+import FileUploadInput from './FileUploadInput.vue';
+import DataSubmitButton from './DataSubmitButton.vue';
+import SelectInput from './SelectInput.vue';
+import RadioInput from './RadioInput.vue';
+
+export { FileUploadInput, DataSubmitButton, SelectInput, RadioInput };

--- a/packages/components/src/components/Panel/PanelBody.vue
+++ b/packages/components/src/components/Panel/PanelBody.vue
@@ -1,18 +1,38 @@
 <script setup lang="ts">
 interface PanelBodyProps {
 	className?: string;
-	padded?: boolean;
+	variant?: 'data-panel' | 'padded' | 'data-panel-padded' | 'default';
 }
 
-const { className = '', padded = true } = defineProps<PanelBodyProps>();
+const { className = '', variant = 'default' } = defineProps<PanelBodyProps>();
 </script>
 
 <template>
-	<div
-		:class="
-			`panel-body ${padded ? 'panel-body--padded' : ''} ${className}`.trim()
-		"
-	>
+	<div :class="`panel-body  panel-body--${variant} ${className}`.trim()">
 		<slot></slot>
 	</div>
 </template>
+
+<style>
+.panel-body {
+	background-color: white;
+	border-radius: 5px;
+}
+
+.panel-body--padded {
+	padding: calc(var(--panel--padding));
+}
+
+.panel-body--data-panel {
+	display: flex;
+	flex-direction: column;
+	gap: var(--fixed-spacing--4x);
+}
+
+.panel-body--data-panel-padded {
+	display: flex;
+	flex-direction: column;
+	gap: var(--fixed-spacing--4x);
+	padding: calc(var(--panel--padding));
+}
+</style>

--- a/packages/components/src/components/Panel/PanelComponent.vue
+++ b/packages/components/src/components/Panel/PanelComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-interface PanelProps {
+export interface PanelProps {
 	className?: string;
 	padded?: boolean;
 }
@@ -26,16 +26,6 @@ const { className = '', padded = false } = defineProps<PanelProps>();
 .panel-padded {
 	padding-left: calc(var(--panel--padding) * 4);
 	padding-right: calc(var(--panel--padding) * 4);
-}
-
-.panel-body {
-	background-color: white;
-	border-radius: 5px;
-	box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
-}
-
-.panel-body--padded {
-	padding: calc(var(--panel--padding));
 }
 
 .panel-header {

--- a/packages/components/src/components/Panel/PanelHeader.vue
+++ b/packages/components/src/components/Panel/PanelHeader.vue
@@ -16,3 +16,9 @@ const { className = '', padded = true } = defineProps<PanelHeaderProps>();
 		<slot></slot>
 	</div>
 </template>
+
+<style scoped>
+.panel-header :deep(h1) {
+	margin: 0;
+}
+</style>

--- a/packages/components/src/components/Panel/PanelSection.vue
+++ b/packages/components/src/components/Panel/PanelSection.vue
@@ -1,0 +1,39 @@
+<template>
+	<div class="panel-section">
+		<div class="panel-section-header">
+			<slot class="header" name="header"></slot>
+		</div>
+		<div class="panel-section-content">
+			<slot name="content"></slot>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped>
+.panel-section {
+	display: flex;
+	width: 100%;
+	align-items: flex-start;
+}
+
+.panel-section-header,
+.panel-section-content {
+	flex: 1;
+	width: 50%;
+	margin-top: 0;
+}
+
+.panel-section-header :deep(h3) {
+	margin-top: 0;
+}
+
+.panel-section :deep(h3) {
+	font-weight: var(--font-weight--medium);
+}
+
+.panel-section :deep(h4) {
+	font-weight: var(--font-weight--medium);
+}
+</style>

--- a/packages/components/src/components/Panel/index.ts
+++ b/packages/components/src/components/Panel/index.ts
@@ -3,6 +3,7 @@ import PanelHeader from './PanelHeader.vue';
 import PanelHeaderAction from './PanelHeaderAction.vue';
 import PanelHeaderActionsWrapper from './PanelHeaderActionsWrapper.vue';
 import PanelBody from './PanelBody.vue';
+import PanelSection from './PanelSection.vue';
 
 export {
 	PanelComponent,
@@ -10,4 +11,5 @@ export {
 	PanelHeaderAction,
 	PanelHeaderActionsWrapper,
 	PanelBody,
+	PanelSection,
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -32,3 +32,10 @@ export {
 	TableHead,
 	TableRow,
 } from './components/Table';
+
+export {
+	DataSubmitButton,
+	FileUploadInput,
+	SelectInput,
+	RadioInput,
+} from './components/DataInputs';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -20,6 +20,7 @@ export {
 	PanelBody,
 	PanelHeaderAction,
 	PanelHeaderActionsWrapper,
+	PanelSection,
 } from './components/Panel';
 
 export {

--- a/packages/components/src/stories/DataSubmitButton.stories.ts
+++ b/packages/components/src/stories/DataSubmitButton.stories.ts
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { ref } from 'vue';
+import { getLogger } from '@pdc/utilities';
+import { DataSubmitButton, RadioInput } from '../components/DataInputs';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+	PanelSection,
+} from '../components/Panel';
+
+const meta = {
+	component: DataSubmitButton,
+	tags: ['autodocs'],
+} satisfies Meta<typeof DataSubmitButton>;
+
+export default meta;
+
+const dataSubmitButtonProps = {
+	disabled: false,
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: dataSubmitButtonProps,
+	render: (args) => ({
+		components: {
+			DataSubmitButton,
+		},
+		setup() {
+			return { args };
+		},
+		template: `<DataSubmitButton>
+			Submit
+		</DataSubmitButton>`,
+	}),
+};
+export const Disabled: Story = {
+	args: dataSubmitButtonProps,
+	render: (args) => ({
+		components: {
+			DataSubmitButton,
+		},
+		setup() {
+			return { args };
+		},
+		template: `<DataSubmitButton :disabled="true">
+			Submit
+		</DataSubmitButton>`,
+	}),
+};
+export const WithRadioInput: Story = {
+	args: dataSubmitButtonProps,
+	render: (args) => ({
+		components: {
+			DataSubmitButton,
+			RadioInput,
+		},
+		setup() {
+			const logger = getLogger('DataSubmitButton.stories');
+			const formData = ref({
+				preference: '',
+			});
+			const radioOptions = [
+				{ label: 'Option A', value: 'option-a' },
+				{ label: 'Option B', value: 'option-b' },
+				{ label: 'Option C', value: 'option-c' },
+			];
+			const handleSubmit = (event: Event): void => {
+				event.preventDefault();
+				logger.info(`Form submitted with: ${JSON.stringify(formData.value)}`);
+			};
+			return { args, formData, radioOptions, handleSubmit };
+		},
+		template: `
+		<form @submit="handleSubmit">
+			<div>
+				<RadioInput
+					:options="radioOptions"
+					v-model="formData.preference"
+				/>
+			</div>
+			<DataSubmitButton :disabled="args.disabled">
+				Submit Selection
+			</DataSubmitButton>
+		</form>`,
+	}),
+};
+
+export const InPanel: Story = {
+	args: dataSubmitButtonProps,
+	render: (args) => ({
+		components: {
+			DataSubmitButton,
+			RadioInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			PanelSection,
+		},
+		setup() {
+			const logger = getLogger('DataSubmitButton.stories');
+			const formData = ref({
+				preference: '',
+			});
+			const radioOptions = [
+				{
+					label: 'High Priority',
+					value: 'high',
+					description: 'Urgent items requiring immediate attention',
+				},
+				{
+					label: 'Medium Priority',
+					value: 'medium',
+					description: 'Important items with moderate urgency',
+				},
+				{
+					label: 'Low Priority',
+					value: 'low',
+					description: 'Items that can be addressed later',
+				},
+			];
+			const handleSubmit = (event: Event): void => {
+				event.preventDefault();
+				logger.info(
+					`Panel form submitted with: ${JSON.stringify(formData.value)}`,
+				);
+			};
+			return { args, formData, radioOptions, handleSubmit };
+		},
+		template: `
+		<PanelComponent padded>
+			<PanelHeader>
+				<h1>Priority Selection</h1>
+			</PanelHeader>
+			<PanelBody variant="data-panel-padded">
+				<form @submit="handleSubmit">
+					<PanelSection>
+						<template #header>
+							<h3>Select Priority Level</h3>
+						</template>
+						<template #content>
+							<RadioInput
+								:options="radioOptions"
+								v-model="formData.preference"
+							/>
+						</template>
+					</PanelSection>
+					<PanelSection>
+						<template #header>
+							<h3>Submit Selection</h3>
+						</template>
+						<template #content>
+							<DataSubmitButton :disabled="args.disabled">
+								Submit
+							</DataSubmitButton>
+						</template>
+					</PanelSection>
+				</form>
+			</PanelBody>
+		</PanelComponent>`,
+	}),
+};

--- a/packages/components/src/stories/FileUploadInput.stories.ts
+++ b/packages/components/src/stories/FileUploadInput.stories.ts
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { FileUploadInput } from '../components/DataInputs';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelSection,
+} from '../components/Panel';
+
+const meta = {
+	component: FileUploadInput,
+	tags: ['autodocs'],
+} satisfies Meta<typeof FileUploadInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+					<FileUploadInput/>
+				`,
+	}),
+};
+
+export const WithHeader: Story = {
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+					<FileUploadInput>
+    <template #file-upload-header>
+        <h4>File Upload Header</h4>
+    </template>
+
+					</FileUploadInput>
+				`,
+	}),
+};
+
+export const WithInstructions: Story = {
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+					<FileUploadInput>
+
+    <template #file-upload-instructions>
+        <p>File Upload Instructions</p>
+    </template>
+
+					</FileUploadInput>
+				`,
+	}),
+};
+
+export const WithHeaderAndInstructions: Story = {
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+					<FileUploadInput>
+    <template #file-upload-header>
+        <h4>File Upload Header</h4>
+    </template>
+    <template #file-upload-instructions>
+        <p>File Upload Instructions</p>
+    </template>
+					</FileUploadInput>
+				`,
+	}),
+};
+
+export const InPanel: Story = {
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelSection,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+		<PanelComponent padded>
+		<PanelHeader>
+			<h1>Upload Data</h1>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+			<PanelSection>
+				<template #header>
+					<h3>File Upload Section Header</h3>
+				</template>
+				<template #content>
+					<FileUploadInput>
+						<template #file-upload-header>
+							<h4>File Upload Header</h3>
+						</template>
+						<template #file-upload-instructions>
+							<p>File Upload Instructions</p>
+						</template>
+					</FileUploadInput>
+				</template>
+			</PanelSection>
+		</PanelBody>
+	</PanelComponent>
+				`,
+	}),
+};

--- a/packages/components/src/stories/RadioInput.stories.ts
+++ b/packages/components/src/stories/RadioInput.stories.ts
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { RadioInput } from '../components/DataInputs';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+	PanelSection,
+} from '../components/Panel';
+
+const meta = {
+	component: RadioInput,
+	tags: ['autodocs'],
+} satisfies Meta<typeof RadioInput>;
+
+export default meta;
+const radioOptions = [
+	{ label: 'Option 1', value: 'option1' },
+	{ label: 'Option 2', value: 'option2' },
+	{ label: 'Option 3', value: 'option3' },
+];
+
+const radioOptionsWithDescription = [
+	{ label: 'Option 1', value: 'option1', description: 'Option 1 description' },
+	{ label: 'Option 2', value: 'option2', description: 'Option 2 description' },
+	{ label: 'Option 3', value: 'option3', description: 'Option 3 description' },
+];
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: {
+			RadioInput,
+		},
+		setup() {
+			return { args, radioOptions };
+		},
+		template: `<RadioInput :options="radioOptions" />`,
+	}),
+};
+export const WithDescription: Story = {
+	render: (args) => ({
+		components: {
+			RadioInput,
+		},
+		setup() {
+			return { args, radioOptionsWithDescription };
+		},
+		template: `<RadioInput :options="radioOptionsWithDescription" />`,
+	}),
+};
+export const InPanel: Story = {
+	render: (args) => ({
+		components: {
+			RadioInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			PanelSection,
+		},
+		setup() {
+			return { args, radioOptionsWithDescription };
+		},
+		template: `<PanelComponent padded>
+		<PanelHeader>
+			<h1>Upload Data</h1>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+
+			<PanelSection>
+					<template #header>
+					<h3>Radio Section Header</h3>
+				</template>
+				<template #content>
+					<RadioInput :options="radioOptionsWithDescription" />
+				</template>
+			</PanelSection>
+
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};

--- a/packages/components/src/stories/SelectInput.stories.ts
+++ b/packages/components/src/stories/SelectInput.stories.ts
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { SelectInput } from '../components/DataInputs';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+	PanelSection,
+} from '../components/Panel';
+
+const meta = {
+	component: SelectInput,
+	tags: ['autodocs'],
+} satisfies Meta<typeof SelectInput>;
+
+export default meta;
+const selectOptions = [
+	{ label: 'Option 1', value: 'option1' },
+	{ label: 'Option 2', value: 'option2' },
+	{ label: 'Option 3', value: 'option3' },
+];
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: {
+			SelectInput,
+		},
+		setup() {
+			return { args, selectOptions };
+		},
+		template: `<SelectInput :options="selectOptions" />`,
+	}),
+};
+export const InPanel: Story = {
+	render: (args) => ({
+		components: {
+			SelectInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			PanelSection,
+		},
+		setup() {
+			return { args, selectOptions };
+		},
+		template: `<PanelComponent padded>
+		<PanelHeader>
+			<h1>Upload Data</h1>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+
+			<PanelSection>
+					<template #header>
+					<h3>Select Section Header</h3>
+				</template>
+				<template #content>
+					<SelectInput :options="selectOptions" />
+				</template>
+			</PanelSection>
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};

--- a/packages/components/src/stories/TableComponent.stories.ts
+++ b/packages/components/src/stories/TableComponent.stories.ts
@@ -104,7 +104,7 @@ export const Default: Story = {
 				</PanelHeaderAction>
 			</PanelHeaderActionsWrapper>
 		</PanelHeader>
-		<PanelBody :padded="false">
+		<PanelBody>
 			<TableComponent
 
 			>
@@ -161,7 +161,7 @@ export const TruncatedTable: Story = {
 				</PanelHeaderAction>
 			</PanelHeaderActionsWrapper>
 		</PanelHeader>
-		<PanelBody :padded="false">
+		<PanelBody>
 			<TableComponent
 				truncate
 			>
@@ -223,7 +223,7 @@ export const WithTwoActions: Story = {
 				</PanelHeaderAction>
 			</PanelHeaderActionsWrapper>
 		</PanelHeader>
-		<PanelBody :padded="false">
+		<PanelBody >
 			<TableComponent truncate>
 				<TableHead fixed>
 					<TableRow>
@@ -269,7 +269,7 @@ export const WithNoActions: Story = {
 		<PanelHeader>
 			<h1>Base Fields</h1>
 		</PanelHeader>
-		<PanelBody :padded="false">
+		<PanelBody>
 			<TableComponent truncate>
 				<TableHead fixed>
 					<TableRow>


### PR DESCRIPTION
# Note This Commit is based off PR #1109 and should not be merged/reviewed until that has been!

These commits add in extendable dataInput components for constructing forms in the PDC for data upload. They are currently only the types of forms we'll be using in the bulk-uploader (file upload, radio, and select forms), but are already intended to be used in the base-field admin interface. It also adds the optional rendering of Panels as DataInput panels, which have their own stylings consistent across applications. 

Closes Issue #1093 