### PR TITLE
Implement bulk uploader add data view

### DIFF
--- a/apps/bulk-uploader/src/components/BaseFieldsTable.vue
+++ b/apps/bulk-uploader/src/components/BaseFieldsTable.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+	PanelBody,
+	TableComponent,
+	TableHead,
+	TableRow,
+	TableBody,
+	TableColumnHead,
+	TableRowCell,
+} from '@pdc/components';
+import { DocumentPlusIcon } from '@heroicons/vue/24/outline';
+import { BaseField } from '@pdc/sdk';
+import { computed } from 'vue';
+
+export interface BaseFieldsTableProps {
+	baseFields: BaseField[] | null;
+	isLoading: boolean;
+}
+
+const props = defineProps<BaseFieldsTableProps>();
+
+const publicBaseFields = computed(() =>
+	props.baseFields?.filter(
+		(baseField) =>
+			baseField.sensitivityClassification ===
+			BaseField.SensitivityClassificationEnum.Public,
+	),
+);
+</script>
+
+<template>
+	<PanelComponent padded>
+		<PanelHeader>
+			<h1>Base Fields</h1>
+			<PanelHeaderActionsWrapper class="disabled">
+				<PanelHeaderAction>
+					<DocumentPlusIcon class="icon" />
+					<p class="download-csv-text">Download CSV template</p>
+				</PanelHeaderAction>
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody :padded="false">
+			<div v-if="isLoading" class="text-center py-8 text-gray-500">
+				<p>Loading base fields...</p>
+			</div>
+
+			<TableComponent
+				v-else-if="props.baseFields && props.baseFields.length > 0"
+				truncate
+			>
+				<TableHead fixed>
+					<TableRow>
+						<TableColumnHead>Label</TableColumnHead>
+						<TableColumnHead>Description</TableColumnHead>
+						<TableColumnHead>Short code</TableColumnHead>
+						<TableColumnHead>Data type</TableColumnHead>
+						<TableColumnHead>Category</TableColumnHead>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow
+						v-for="baseField in publicBaseFields"
+						:key="baseField.label"
+					>
+						<TableRowCell>{{ baseField.label }}</TableRowCell>
+						<TableRowCell>{{ baseField.description }}</TableRowCell>
+						<TableRowCell>{{ baseField.shortCode }}</TableRowCell>
+						<TableRowCell>{{ baseField.dataType }}</TableRowCell>
+						<TableRowCell>{{ baseField.category }}</TableRowCell>
+					</TableRow>
+				</TableBody>
+			</TableComponent>
+
+			<div v-else>
+				<p>No base fields found</p>
+			</div>
+		</PanelBody>
+	</PanelComponent>
+</template>
+
+<style scoped>
+.download-csv-text {
+	font-weight: 700;
+}
+
+.disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+</style>

--- a/apps/bulk-uploader/src/components/BulkUploader.vue
+++ b/apps/bulk-uploader/src/components/BulkUploader.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+import type { FunderBundle, SourceBundle } from '@pdc/sdk';
+import {
+	PanelComponent,
+	PanelBody,
+	PanelHeader,
+	PanelHeaderAction,
+	PanelHeaderActionsWrapper,
+	PanelSection,
+	FileUploadInput,
+	DataSubmitButton,
+	SelectInput,
+} from '@pdc/components';
+import { ArrowLeftIcon, XCircleIcon } from '@heroicons/vue/24/outline';
+import { RouterLink } from 'vue-router';
+import { getLogger } from '@pdc/utilities';
+import { ref } from 'vue';
+
+const props = defineProps<{
+	bulkUpload: File | null;
+	sourceId: string | null;
+	funderShortCode: string | null;
+	sources: SourceBundle | null;
+	funders: FunderBundle | null;
+	defaultFunderShortCode: string;
+	handleBulkUpload: (file: File) => Promise<void>;
+}>();
+
+const emit = defineEmits<{
+	'update:bulk-upload': [file: File | null];
+	'update:source-id': [sourceId: string | null];
+	'update:funder-short-code': [funderShortCode: string | null];
+}>();
+
+const logger = getLogger('BulkUploader');
+const hadError = ref(false);
+
+const handleFormSubmit = async (event: Event): Promise<void> => {
+	event.preventDefault();
+
+	if (props.bulkUpload === null) {
+		logger.warn('Attempted to submit form without a file');
+		return;
+	}
+
+	try {
+		await props.handleBulkUpload(props.bulkUpload);
+		logger.info('Bulk upload submitted successfully');
+	} catch (error) {
+		logger.error({ error }, 'Failed to submit bulk upload');
+		hadError.value = true;
+	}
+};
+</script>
+
+<template>
+	<PanelComponent padded>
+		<PanelHeader>
+			<h1>New Bulk Upload</h1>
+			<PanelHeaderActionsWrapper>
+				<PanelHeaderAction>
+					<ArrowLeftIcon class="icon" />
+					<RouterLink to="/bulk-uploads">Back to bulk uploads</RouterLink>
+				</PanelHeaderAction>
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+			<form @submit="handleFormSubmit">
+				<PanelSection>
+					<template #header>
+						<h3>Select File to Upload</h3>
+						<p class="text-color-gray-medium-dark">
+							File format guidance and instructions here.
+						</p>
+					</template>
+					<template #content>
+						<FileUploadInput
+							:model-value="props.bulkUpload"
+							@update:model-value="
+								(value: File | null | undefined) =>
+									emit('update:bulk-upload', value ?? null)
+							"
+						>
+							<template #file-upload-header>
+								<h4>Choose File</h4>
+							</template>
+							<template #file-upload-instructions>
+								<p class="text-color-gray-medium-dark">
+									Drag and drop a CSV file into the box above, or click it to
+									use the file picker.
+								</p>
+							</template>
+						</FileUploadInput>
+					</template>
+				</PanelSection>
+				<PanelSection>
+					<template #header>
+						<h3>Associated Entities</h3>
+					</template>
+					<template #content>
+						<SelectInput
+							:model-value="props.sourceId"
+							:options="
+								props.sources?.entries.map((source) => ({
+									label: source.label,
+									value: source.id.toString(),
+								}))
+							"
+							@update:model-value="
+								(value: string | null | undefined) =>
+									emit('update:source-id', value ?? null)
+							"
+						>
+							<template #select-input-header>
+								<h4>Source</h4>
+							</template>
+							<template #select-input-instructions>
+								<p class="text-color-gray-medium-dark">
+									If blank, the default source in the pdc instance will be used
+									for the bulk upload.
+								</p>
+							</template>
+						</SelectInput>
+						<SelectInput
+							:model-value="props.funderShortCode"
+							:options="
+								props.funders?.entries.map((funder) => ({
+									label: funder.name,
+									value: funder.shortCode,
+								}))
+							"
+							@update:model-value="
+								(value: string | null | undefined) =>
+									emit('update:funder-short-code', value ?? null)
+							"
+						>
+							<template #select-input-header>
+								<h4>Funder</h4>
+							</template>
+							<template #select-input-instructions>
+								<p class="text-color-gray-medium-dark">
+									If blank, the system funder shortcode will be used (default is
+									`{{ defaultFunderShortCode }}`)
+								</p>
+							</template>
+						</SelectInput>
+					</template>
+				</PanelSection>
+				<PanelSection>
+					<template #header>
+						<div v-if="props.bulkUpload">
+							<h3>Ready to upload</h3>
+							<p class="text-color-gray-medium-dark">
+								All required data has been provided.
+							</p>
+						</div>
+						<div v-else>
+							<h3>Not quite ready</h3>
+							<p class="text-color-gray-medium-dark">
+								Please select a file above.
+							</p>
+						</div>
+					</template>
+					<template #content>
+						<DataSubmitButton :disabled="props.bulkUpload === null">
+							Submit
+						</DataSubmitButton>
+						<div v-if="hadError" class="error-message">
+							<XCircleIcon class="icon" />
+							<p>An error occurred while submitting the bulk upload.</p>
+						</div>
+					</template>
+				</PanelSection>
+			</form>
+		</PanelBody>
+	</PanelComponent>
+</template>
+
+<style scoped>
+.error-message {
+	color: var(--color--red--dark);
+	display: flex;
+	align-items: center;
+}
+</style>

--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -1,15 +1,120 @@
-import { usePdcApi } from '@pdc/utilities';
-import type { BulkUploadTaskBundle } from '@pdc/sdk';
+import { usePdcApi, usePdcCallbackApi, throwIfNotOk } from '@pdc/utilities';
+import type {
+	BulkUploadTaskBundle,
+	Source,
+	PresignedPostRequest,
+	WritablePresignedPostRequest,
+	PresignedPost,
+	WritableBulkUploadTask,
+	BulkUploadTask,
+	SourceBundle,
+	FunderBundle,
+	BaseField,
+} from '@pdc/sdk';
 
-const BULK_UPLOADS_DEFAULT_PAGE = 1;
-const BULK_UPLOADS_DEFAULT_COUNT = 200;
+const DEFAULT_ENTITY_PAGE = 1;
+const DEFAULT_ENTITY_COUNT = 200;
 
 export function useBulkUploads(
-	page: number = BULK_UPLOADS_DEFAULT_PAGE,
-	count: number = BULK_UPLOADS_DEFAULT_COUNT,
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
 ): ReturnType<typeof usePdcApi<BulkUploadTaskBundle>> {
 	return usePdcApi<BulkUploadTaskBundle>(
 		'/tasks/bulkUploads',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useSystemSource(): ReturnType<typeof usePdcApi<Source>> {
+	return usePdcApi<Source>('/sources/1');
+}
+
+export const usePresignedPostCallback = () => {
+	const api = usePdcCallbackApi<PresignedPostRequest>('/presignedPostRequests');
+	return async (params: WritablePresignedPostRequest) =>
+		await api({
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(params),
+		});
+};
+
+const isStringOrBlob = (value: unknown): value is string | Blob =>
+	typeof value === 'string' || value instanceof Blob;
+
+export const uploadUsingPresignedPost = async (
+	file: File,
+	presignedPost: PresignedPost,
+): Promise<Response> => {
+	const formData = new FormData();
+	Object.entries(presignedPost.fields).forEach(([key, value]) => {
+		if (isStringOrBlob(value)) {
+			formData.append(key, value);
+		}
+	});
+	formData.append(
+		'Content-Type',
+		file.type !== '' ? file.type : 'application/octet-stream',
+	);
+	formData.append('file', file);
+
+	return await fetch(presignedPost.url, {
+		method: 'POST',
+		body: formData,
+	}).then(throwIfNotOk);
+};
+
+export const useRegisterBulkUploadCallback = () => {
+	const api = usePdcCallbackApi<BulkUploadTask>('/tasks/bulkUploads');
+	return async (params: WritableBulkUploadTask) =>
+		await api({
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(params),
+		});
+};
+
+export function useSources(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<SourceBundle>> {
+	return usePdcApi<SourceBundle>(
+		'/sources',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useFunders(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<FunderBundle>> {
+	return usePdcApi<FunderBundle>(
+		'/funders',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useBaseFields(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<BaseField[]>> {
+	return usePdcApi<BaseField[]>(
+		'/baseFields',
 		new URLSearchParams({
 			_page: page.toString(),
 			_count: count.toString(),

--- a/apps/bulk-uploader/src/router.ts
+++ b/apps/bulk-uploader/src/router.ts
@@ -4,10 +4,12 @@ import NotFoundView from './views/NotFoundView.vue';
 import type { Router } from 'vue-router';
 import BulkUploadsView from './views/BulkUploadsView.vue';
 import BulkUploadView from './views/BulkUploadView.vue';
+import AddDataView from './views/AddDataView.vue';
 
 const routes = [
 	{ path: '/', component: LandingView },
 	{ path: '/bulk-uploads', component: BulkUploadsView },
+	{ path: '/add-data', component: AddDataView },
 	{ path: '/bulk-uploads/:id', component: BulkUploadView },
 	{ path: '/:pathMatch(.*)', component: NotFoundView },
 ];

--- a/apps/bulk-uploader/src/views/AddDataView.vue
+++ b/apps/bulk-uploader/src/views/AddDataView.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import { ref, onMounted } from 'vue';
+import {
+	useSystemSource,
+	usePresignedPostCallback,
+	useRegisterBulkUploadCallback,
+	uploadUsingPresignedPost,
+	useSources,
+	useFunders,
+	useBaseFields,
+} from '../pdc-api';
+import { getLogger } from '@pdc/utilities';
+import BulkUploader from '../components/BulkUploader.vue';
+import BaseFieldsTable from '../components/BaseFieldsTable.vue';
+
+const logger = getLogger('<AddDataView>');
+
+const router = useRouter();
+const bulkUpload = ref<File | null>(null);
+
+const sourceId = ref<string | null>(null);
+const funderShortCode = ref<string | null>(null);
+
+const { data: sources } = useSources();
+const { data: funders } = useFunders();
+
+const { data: systemSource, fetchData: fetchSystemSource } = useSystemSource();
+const { data: baseFields, fetchData: fetchBaseFields } = useBaseFields();
+const isLoading = ref(true);
+
+const createPresignedPost = usePresignedPostCallback();
+const registerBulkUpload = useRegisterBulkUploadCallback();
+
+const defaultFunderShortCode = 'pdc';
+
+onMounted(async () => {
+	await fetchSystemSource();
+	try {
+		await fetchBaseFields();
+	} catch (error: unknown) {
+		logger.error({ error }, 'Failed to load base fields');
+	} finally {
+		isLoading.value = false;
+	}
+});
+const handleBulkUpload = async (file: File): Promise<void> => {
+	if (systemSource.value?.id == null) {
+		throw new Error('No System Source Available');
+	}
+	const { presignedPost } = await createPresignedPost({
+		fileType: file.type !== '' ? file.type : 'application/octet-stream',
+		fileSize: file.size,
+	});
+
+	await uploadUsingPresignedPost(file, presignedPost);
+	const selectedSourceId =
+		sourceId.value !== null && sourceId.value !== ''
+			? Number(sourceId.value)
+			: systemSource.value.id;
+	const selectedFunderShortCode =
+		funderShortCode.value ?? defaultFunderShortCode;
+	const bulkUploadResult = await registerBulkUpload({
+		fileName: file.name,
+		sourceKey: presignedPost.fields.key,
+		sourceId: selectedSourceId,
+		funderShortCode: selectedFunderShortCode,
+	});
+
+	await router.push(`/bulk-uploads/${bulkUploadResult.id}`);
+};
+</script>
+
+<template>
+	<BulkUploader
+		v-model:bulk-upload="bulkUpload"
+		v-model:source-id="sourceId"
+		v-model:funder-short-code="funderShortCode"
+		:sources="sources"
+		:funders="funders"
+		:handle-bulk-upload="handleBulkUpload"
+		:default-funder-short-code="defaultFunderShortCode"
+	/>
+	<BaseFieldsTable :base-fields="baseFields" :is-loading="isLoading" />
+</template>
+
+<style scoped></style>

--- a/apps/bulk-uploader/src/views/LandingView.vue
+++ b/apps/bulk-uploader/src/views/LandingView.vue
@@ -11,7 +11,6 @@ import {
 } from '@pdc/components';
 import { getLogger } from '@pdc/utilities';
 const logger = getLogger('<LandingView>');
-
 const { authenticated, login } = useKeycloak();
 
 const handleLogin = async (): Promise<void> => {

--- a/packages/utilities/src/api-hooks.ts
+++ b/packages/utilities/src/api-hooks.ts
@@ -53,3 +53,27 @@ export function usePdcApi<T>(
 
 	return { data, fetchData };
 }
+
+export function usePdcCallbackApi<T>(
+	path: string,
+): (options: RequestInit) => Promise<T> {
+	return async (options: RequestInit): Promise<T> => {
+		try {
+			const { token } = useKeycloak();
+			const url = new URL(path, API_URL);
+			const res = await fetch(url.toString(), {
+				...options,
+				headers: {
+					Authorization: `Bearer ${token}`,
+					...Object.fromEntries(Object.entries(options.headers ?? {})),
+				},
+			}).then(throwIfNotOk);
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Assuming valid JSON response from API
+			return (await res.json()) as T;
+		} catch (error) {
+			logger.error({ error, params: options }, `Error calling ${path}`);
+			throw error;
+		}
+	};
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,4 +1,4 @@
 export { getLogger, type Logger } from './logger';
 export { reportWebVitals } from './reportWebVitals';
-export { usePdcApi } from './api-hooks';
+export { usePdcApi, usePdcCallbackApi, throwIfNotOk } from './api-hooks';
 export { localizeDateTime, relativizeDateTime } from './utils/datetime';


### PR DESCRIPTION
# Note: This PR is based off of #1112 And should not be merged until that has been reviewed/merged!

This PR adds a view for adding bulk uploads to the PDC, bringing together the work we did in #1110 to support data upload, as well as adding a suite of necessary api hooks. It is heavily modeled off of the workflow we'd designed for the [previous iteration of the application](https://github.com/PhilanthropyDataCommons/front-end/blob/b1dcd3a4960ccd014a4dc0a6101431f079f69ace/src/pdc-api.ts). 

Closes #1066 