### PR TITLE
Update PresignedPostRequest to File

### DIFF
--- a/apps/admin-interface/package.json
+++ b/apps/admin-interface/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.22.2",
+		"@pdc/sdk": "^0.23.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.20",
 		"dayjs": "^1.11.18",

--- a/apps/bulk-uploader/package.json
+++ b/apps/bulk-uploader/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.22.2",
+		"@pdc/sdk": "^0.23.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.20",
 		"dayjs": "^1.11.18",

--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -2,8 +2,8 @@ import { usePdcApi, usePdcCallbackApi, throwIfNotOk } from '@pdc/utilities';
 import type {
 	BulkUploadTaskBundle,
 	Source,
-	PresignedPostRequest,
-	WritablePresignedPostRequest,
+	ModelFile,
+	WritableModelFile,
 	PresignedPost,
 	WritableBulkUploadTask,
 	BulkUploadTask,
@@ -11,6 +11,10 @@ import type {
 	FunderBundle,
 	BaseField,
 } from '@pdc/sdk';
+
+type fileUploadResponse = ModelFile & {
+	presignedPost: PresignedPost;
+};
 
 const DEFAULT_ENTITY_PAGE = 1;
 const DEFAULT_ENTITY_COUNT = 200;
@@ -32,9 +36,9 @@ export function useSystemSource(): ReturnType<typeof usePdcApi<Source>> {
 	return usePdcApi<Source>('/sources/1');
 }
 
-export const usePresignedPostCallback = () => {
-	const api = usePdcCallbackApi<PresignedPostRequest>('/presignedPostRequests');
-	return async (params: WritablePresignedPostRequest) =>
+export const useFileUploadCallback = () => {
+	const api = usePdcCallbackApi<fileUploadResponse>('/files');
+	return async (params: WritableModelFile) =>
 		await api({
 			method: 'POST',
 			headers: {
@@ -63,7 +67,6 @@ export const uploadUsingPresignedPost = async (
 		file.type !== '' ? file.type : 'application/octet-stream',
 	);
 	formData.append('file', file);
-
 	return await fetch(presignedPost.url, {
 		method: 'POST',
 		body: formData,

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.22.2",
+				"@pdc/sdk": "^0.23.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.20",
 				"dayjs": "^1.11.18",
@@ -62,6 +62,12 @@
 				"node": ">=22"
 			}
 		},
+		"apps/admin-interface/node_modules/@pdc/sdk": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
+			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
+			"license": "AGPL-3.0"
+		},
 		"apps/bulk-uploader": {
 			"name": "@pdc/bulk-uploader",
 			"version": "0.0.0",
@@ -69,7 +75,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.22.2",
+				"@pdc/sdk": "^0.23.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.20",
 				"dayjs": "^1.11.18",
@@ -83,6 +89,12 @@
 			"engines": {
 				"node": ">=22"
 			}
+		},
+		"apps/bulk-uploader/node_modules/@pdc/sdk": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
+			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
+			"license": "AGPL-3.0"
 		},
 		"node_modules/@adobe/css-tools": {
 			"version": "4.4.3",
@@ -1149,12 +1161,6 @@
 		"node_modules/@pdc/components": {
 			"resolved": "packages/components",
 			"link": true
-		},
-		"node_modules/@pdc/sdk": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.22.2.tgz",
-			"integrity": "sha512-bQ7emqbj97VkkOyFtxg3kp7N56MmkrOVz9zyJa+5boL7ZQEvCpD0erbPc52caSTAoehK3eDqbTCUhF96cEsBOg==",
-			"license": "AGPL-3.0"
 		},
 		"node_modules/@pdc/utilities": {
 			"resolved": "packages/utilities",
@@ -8023,7 +8029,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.22.2",
+				"@pdc/sdk": "^0.23.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.20",
 				"dayjs": "^1.11.18",
@@ -8034,6 +8040,12 @@
 				"vue-router": "^4.5.1",
 				"web-vitals": "^5.1.0"
 			}
+		},
+		"packages/components/node_modules/@pdc/sdk": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
+			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
+			"license": "AGPL-3.0"
 		},
 		"packages/shared": {
 			"name": "@pdc/shared",
@@ -8080,7 +8092,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
-				"@pdc/sdk": "^0.22.2",
+				"@pdc/sdk": "^0.23.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.20",
 				"dayjs": "^1.11.18",
@@ -8091,6 +8103,12 @@
 				"vue-router": "^4.5.1",
 				"web-vitals": "^5.1.0"
 			}
+		},
+		"packages/utilities/node_modules/@pdc/sdk": {
+			"version": "0.23.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
+			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
+			"license": "AGPL-3.0"
 		}
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.22.2",
+		"@pdc/sdk": "^0.23.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.20",
 		"dayjs": "^1.11.18",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
-		"@pdc/sdk": "^0.22.2",
+		"@pdc/sdk": "^0.23.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.20",
 		"dayjs": "^1.11.18",


### PR DESCRIPTION
This commit changes all references from PresignedPostRequests to the new File entity, as defined in service issue #1689. The functionality of the two entities are the same, so the only changes needed to be made are in the naming of our hooks and the route we're calling.

Closes #1127 