### PR TITLE
Update BulkUpload tasks to reference file entities

### DIFF
--- a/apps/admin-interface/package.json
+++ b/apps/admin-interface/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.23.1",
+		"@pdc/sdk": "^0.24.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.21",
 		"dayjs": "^1.11.18",

--- a/apps/bulk-uploader/package.json
+++ b/apps/bulk-uploader/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.23.1",
+		"@pdc/sdk": "^0.24.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.21",
 		"dayjs": "^1.11.18",

--- a/apps/bulk-uploader/src/views/AddDataView.vue
+++ b/apps/bulk-uploader/src/views/AddDataView.vue
@@ -29,7 +29,7 @@ const { data: systemSource, fetchData: fetchSystemSource } = useSystemSource();
 const { data: baseFields, fetchData: fetchBaseFields } = useBaseFields();
 const isLoading = ref(true);
 
-const createPresignedPost = useFileUploadCallback();
+const createPdcFile = useFileUploadCallback();
 const registerBulkUpload = useRegisterBulkUploadCallback();
 
 const defaultFunderShortCode = 'pdc';
@@ -48,13 +48,13 @@ const handleBulkUpload = async (file: File): Promise<void> => {
 	if (systemSource.value?.id == null) {
 		throw new Error('No System Source Available');
 	}
-	const { presignedPost, storageKey } = await createPresignedPost({
+	const proposalsDataFile = await createPdcFile({
 		mimeType: file.type !== '' ? file.type : 'application/octet-stream',
 		size: file.size,
 		name: file.name,
 	});
 
-	await uploadUsingPresignedPost(file, presignedPost);
+	await uploadUsingPresignedPost(file, proposalsDataFile.presignedPost);
 
 	const selectedSourceId =
 		sourceId.value !== null && sourceId.value !== ''
@@ -64,8 +64,7 @@ const handleBulkUpload = async (file: File): Promise<void> => {
 		funderShortCode.value ?? defaultFunderShortCode;
 
 	const bulkUploadResult = await registerBulkUpload({
-		fileName: file.name,
-		sourceKey: storageKey,
+		proposalsDataFileId: proposalsDataFile.id,
 		sourceId: selectedSourceId,
 		funderShortCode: selectedFunderShortCode,
 	});

--- a/apps/bulk-uploader/src/views/BulkUploadView.vue
+++ b/apps/bulk-uploader/src/views/BulkUploadView.vue
@@ -99,9 +99,7 @@ onUnmounted(() => {
 							<h4>Original File</h4>
 							<div class="file-download">
 								<DocumentPlusIcon class="icon" />
-								<p :href="bulkUpload.fileName" target="_blank">
-									TO DO: IMPLEMENT
-								</p>
+								<p>TO DO: IMPLEMENT</p>
 							</div>
 						</div>
 						<h4>Job ID</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.23.1",
+				"@pdc/sdk": "^0.24.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.21",
 				"dayjs": "^1.11.18",
@@ -61,12 +61,6 @@
 			"engines": {
 				"node": ">=22"
 			}
-		},
-		"apps/admin-interface/node_modules/@pdc/sdk": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
-			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
-			"license": "AGPL-3.0"
 		},
 		"apps/bulk-uploader": {
 			"name": "@pdc/bulk-uploader",
@@ -75,7 +69,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.23.1",
+				"@pdc/sdk": "^0.24.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.21",
 				"dayjs": "^1.11.18",
@@ -89,12 +83,6 @@
 			"engines": {
 				"node": ">=22"
 			}
-		},
-		"apps/bulk-uploader/node_modules/@pdc/sdk": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
-			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
-			"license": "AGPL-3.0"
 		},
 		"node_modules/@adobe/css-tools": {
 			"version": "4.4.3",
@@ -1162,6 +1150,12 @@
 		"node_modules/@pdc/components": {
 			"resolved": "packages/components",
 			"link": true
+		},
+		"node_modules/@pdc/sdk": {
+			"version": "0.24.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.24.1.tgz",
+			"integrity": "sha512-6RCZdIdbR6sAZ7j4IxFVdulaxPkncP8jy5NsVMYxUskh6IcadMsG/KYFbwSpONZcoIUm0lqyhZETgebito5HYw==",
+			"license": "AGPL-3.0"
 		},
 		"node_modules/@pdc/utilities": {
 			"resolved": "packages/utilities",
@@ -8033,7 +8027,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.23.1",
+				"@pdc/sdk": "^0.24.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.21",
 				"dayjs": "^1.11.18",
@@ -8044,12 +8038,6 @@
 				"vue-router": "^4.5.1",
 				"web-vitals": "^5.1.0"
 			}
-		},
-		"packages/components/node_modules/@pdc/sdk": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
-			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
-			"license": "AGPL-3.0"
 		},
 		"packages/shared": {
 			"name": "@pdc/shared",
@@ -8096,7 +8084,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@dsb-norge/vue-keycloak-js": "^3.0.3",
-				"@pdc/sdk": "^0.23.1",
+				"@pdc/sdk": "^0.24.1",
 				"@vitejs/plugin-vue": "^6.0.1",
 				"@vue/compiler-sfc": "^3.5.21",
 				"dayjs": "^1.11.18",
@@ -8107,12 +8095,6 @@
 				"vue-router": "^4.5.1",
 				"web-vitals": "^5.1.0"
 			}
-		},
-		"packages/utilities/node_modules/@pdc/sdk": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.23.1.tgz",
-			"integrity": "sha512-5KauTKtdDpSu+BiNqbIyzKaUe4nrtIzL2lGsIw8VTIn7fbRmhyUh1TCcbp1uuWXMiBhkrit/9tK8OoR2qczpUw==",
-			"license": "AGPL-3.0"
 		}
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.23.1",
+		"@pdc/sdk": "^0.24.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.21",
 		"dayjs": "^1.11.18",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@dsb-norge/vue-keycloak-js": "^3.0.3",
-		"@pdc/sdk": "^0.23.1",
+		"@pdc/sdk": "^0.24.1",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/compiler-sfc": "^3.5.21",
 		"dayjs": "^1.11.18",


### PR DESCRIPTION
This commit updates our bulkuploader to fit the latest service spec, such that bulkUploadTasks now reference file entities directly in their creation. It also updates the sdk to the latest version across our apps and packages.

It also removes a (currently unused) tag in `/BulkUploadView`, which was intended as a placeholder for downloading the original file of a bulkupload. It accessed a now-deprecated field on the bulkUploadTask entity, but importantly also highlighted an error in our swagger-gen: currently the BulkUploadTask entity has it's 'proposalDataFile' improperly typed as any. We will need to resolve that on the service end.

Closes #1140 