### PR TITLE
Make explicit note of proposal submitter email field

### DIFF
--- a/apps/bulk-uploader/src/components/BulkUploader.vue
+++ b/apps/bulk-uploader/src/components/BulkUploader.vue
@@ -69,6 +69,10 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 				<PanelSection>
 					<template #header>
 						<h3>Select File to Upload</h3>
+						<p class="text-color-gray-medium-dark">
+							A bulk-upload must have a valid email address in the
+							proposal_submitter_email address column.
+						</p>
 					</template>
 					<template #content>
 						<FileUploadInput


### PR DESCRIPTION
This commit makes an explicit note of the requirement of the proposal submitter email field in a bulk-upload, as bulk-uploads without that field will fail.

Closes #1167 