### PR TITLE
Consolidate dependabot to single package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    versioning-strategy: 'increase'
     schedule:
       interval: 'weekly'
       timezone: 'America/Los_Angeles'
@@ -22,26 +23,6 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
-
-  - package-ecosystem: 'npm'
-    directory: '/apps/admin-interface'
-    schedule:
-      interval: 'weekly'
-
-  - package-ecosystem: 'npm'
-    directory: '/apps/bulk-uploader'
-    schedule:
-      interval: 'weekly'
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/components'
-    schedule:
-      interval: 'weekly'
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/utilities'
-    schedule:
-      interval: 'weekly'
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'


### PR DESCRIPTION
This commit consolidates our dependabot app/package configurations into a single config, as per issue #4993 in dependabots repo[1]. We tried the individual configurations for package updating, but it seems like that is neither recommended nor functional, as we were breaking CI/CD with the latest upgrade of a package. This we believe was caused by the lack of the 'versioning-strategy increase' value, which is needed in a monorepo.

[1]https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027

Closes #1189 