### PR TITLE
Add relevance duration unit of time

### DIFF
--- a/apps/admin-interface/src/views/BaseFieldsView.vue
+++ b/apps/admin-interface/src/views/BaseFieldsView.vue
@@ -73,7 +73,7 @@ onMounted(async () => {
 						<TableColumnHead>Short code</TableColumnHead>
 						<TableColumnHead>Data type</TableColumnHead>
 						<TableColumnHead>Category</TableColumnHead>
-						<TableColumnHead>Relevance Duration</TableColumnHead>
+						<TableColumnHead>Relevance Duration (hours)</TableColumnHead>
 						<TableColumnHead></TableColumnHead>
 					</TableRow>
 				</TableHead>


### PR DESCRIPTION
This tiny commit clarifies that the relevance duration for basefields are stored as hours.

Closes #1196 