### PR TITLE
Render keycloak username for bulkupload creators

### DIFF
--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -10,6 +10,7 @@ import type {
 	SourceBundle,
 	FunderBundle,
 	BaseField,
+	UserBundle,
 } from '@pdc/sdk';
 
 type fileUploadResponse = ModelFile & {
@@ -118,6 +119,19 @@ export function useBaseFields(
 ): ReturnType<typeof usePdcApi<BaseField[]>> {
 	return usePdcApi<BaseField[]>(
 		'/baseFields',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useUsers(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<UserBundle>> {
+	return usePdcApi<UserBundle>(
+		'/users',
 		new URLSearchParams({
 			_page: page.toString(),
 			_count: count.toString(),


### PR DESCRIPTION
This commit adds an additional fetch on the bulkUploadsView to the users endpoint, which it uses to get the username from the bulkuploads `createdBy` field, which is a keycloak user id. It couples the bulkuploads and users fetches into a single transaction, which seems like a safer design choice moving forward (we should likely refactor other fetches in our apps that fetch from multiple endpoints).

Closes #1192 