### PR TITLE
Add API error logging

### DIFF
--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -12,6 +12,7 @@ import type {
 	BaseField,
 	UserBundle,
 } from '@pdc/sdk';
+import type { Ref } from 'vue';
 
 type fileUploadResponse = ModelFile & {
 	presignedPost: PresignedPost;
@@ -74,8 +75,8 @@ export const uploadUsingPresignedPost = async (
 	}).then(throwIfNotOk);
 };
 
-export const useRegisterBulkUploadCallback = () => {
-	const api = usePdcCallbackApi<BulkUploadTask>('/tasks/bulkUploads');
+export const useRegisterBulkUploadCallback = (error?: Ref<Response | null>) => {
+	const api = usePdcCallbackApi<BulkUploadTask>('/tasks/bulkUploads', error);
 	return async (params: WritableBulkUploadTask) =>
 		await api({
 			method: 'POST',

--- a/apps/bulk-uploader/src/views/AddDataView.vue
+++ b/apps/bulk-uploader/src/views/AddDataView.vue
@@ -28,9 +28,10 @@ const { data: funders } = useFunders();
 const { data: systemSource, fetchData: fetchSystemSource } = useSystemSource();
 const { data: baseFields, fetchData: fetchBaseFields } = useBaseFields();
 const isLoading = ref(true);
+const uploadError = ref<Response | null>(null);
 
 const createPdcFile = useFileUploadCallback();
-const registerBulkUpload = useRegisterBulkUploadCallback();
+const registerBulkUpload = useRegisterBulkUploadCallback(uploadError);
 
 const defaultFunderShortCode = 'pdc';
 
@@ -62,7 +63,6 @@ const handleBulkUpload = async (file: File): Promise<void> => {
 			: systemSource.value.id;
 	const selectedFunderShortCode =
 		funderShortCode.value ?? defaultFunderShortCode;
-
 	const bulkUploadResult = await registerBulkUpload({
 		proposalsDataFileId: proposalsDataFile.id,
 		sourceId: selectedSourceId,
@@ -72,7 +72,6 @@ const handleBulkUpload = async (file: File): Promise<void> => {
 		attachmentsArchiveFile: null,
 		logs: [],
 	});
-
 	await router.push(`/bulk-uploads/${bulkUploadResult.id}`);
 };
 </script>
@@ -86,6 +85,7 @@ const handleBulkUpload = async (file: File): Promise<void> => {
 		:funders="funders"
 		:handle-bulk-upload="handleBulkUpload"
 		:default-funder-short-code="defaultFunderShortCode"
+		:upload-error="uploadError"
 	/>
 	<BaseFieldsTable :base-fields="baseFields" :is-loading="isLoading" />
 </template>

--- a/packages/components/src/components/ErrorMessage.vue
+++ b/packages/components/src/components/ErrorMessage.vue
@@ -3,20 +3,52 @@ import { XCircleIcon } from '@heroicons/vue/24/outline';
 
 defineProps<{
 	message: string;
+	mode?: 'json';
 }>();
 </script>
 
 <template>
-	<div class="error-message">
-		<XCircleIcon class="icon" />
-		<p>{{ message }}</p>
+	<div class="error-container">
+		<div v-if="mode === 'json'">
+			<div class="error-header">
+				<XCircleIcon class="icon" />
+				<p>Error</p>
+			</div>
+			<pre class="error-message">{{ message }}</pre>
+		</div>
+		<div v-else class="error-simple">
+			<XCircleIcon class="icon" />
+			<p>{{ message }}</p>
+		</div>
 	</div>
 </template>
 
 <style scoped>
-.error-message {
+.error-container {
 	color: var(--color--red--dark);
+}
+
+.error-header {
 	display: flex;
 	align-items: center;
+	gap: 0.5rem;
+	font-size: 1.25rem;
+}
+
+.error-simple {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.error-simple p {
+	margin: 0;
+}
+
+.error-message {
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	white-space: pre-wrap;
+	font-family: inherit;
 }
 </style>

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -3,3 +3,4 @@ export { reportWebVitals } from './reportWebVitals';
 export { usePdcApi, usePdcCallbackApi, throwIfNotOk } from './api-hooks';
 export { localizeDateTime, relativizeDateTime } from './utils/datetime';
 export { dateCompare } from './utils/dateCompare';
+export const JSON_INDENTATION_LEVEL = 2;


### PR DESCRIPTION
This commit expands the current error logging for the scenario when a bulkuploadtask is rejected by the service. This is not explicitly related to rendering the log files for the bulkUploads that are successfully posted, but then fail.

Closes #1163