### PR TITLE
Add BulkUpload logs to individual bulkupload page

### DIFF
--- a/apps/bulk-uploader/src/views/BulkUploadView.vue
+++ b/apps/bulk-uploader/src/views/BulkUploadView.vue
@@ -117,7 +117,7 @@ onUnmounted(() => {
 						<h4>Upload Result</h4>
 						<p><BulkUploadStatus :status="bulkUpload.status" /></p>
 						<h4>Errors Encountered</h4>
-						<p>TODO: Implement</p>
+						<pre>{{ bulkUpload.logs }}</pre>
 						<h4>Proposals Added</h4>
 						<p>TODO: Implement</p>
 					</div>


### PR DESCRIPTION
This commit renders the logs for the bulkuploads in the case that any are generated. This is primarily used for debugging failed bulkuploads.

Closes #1200
