### PR TITLE
Add File Attachment handling

### DIFF
--- a/apps/bulk-uploader/src/components/BulkUploader.vue
+++ b/apps/bulk-uploader/src/components/BulkUploader.vue
@@ -16,16 +16,18 @@ import { ref } from 'vue';
 
 const props = defineProps<{
 	bulkUpload: File | null;
+	attachmentsUpload: File | null;
 	sourceId: string | null;
 	funderShortCode: string | null;
 	sources: SourceBundle | null;
 	funders: FunderBundle | null;
 	defaultFunderShortCode: string;
-	handleBulkUpload: (file: File) => Promise<void>;
+	handleBulkUpload: (file: File, attachmentsFile: File | null) => Promise<void>;
 }>();
 
 const emit = defineEmits<{
 	'update:bulk-upload': [file: File | null];
+	'update:attachments-upload': [file: File | null];
 	'update:source-id': [sourceId: string | null];
 	'update:funder-short-code': [funderShortCode: string | null];
 }>();
@@ -43,7 +45,7 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 	}
 
 	try {
-		await props.handleBulkUpload(props.bulkUpload);
+		await props.handleBulkUpload(props.bulkUpload, props.attachmentsUpload);
 		logger.info('Bulk upload submitted successfully');
 	} catch (error) {
 		logger.error({ error }, 'Failed to submit bulk upload');
@@ -68,14 +70,16 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 			<form @submit="handleFormSubmit">
 				<PanelSection>
 					<template #header>
-						<h3>Select File to Upload</h3>
+						<h3>Select CSV File to Upload</h3>
 						<p class="text-color-gray-medium-dark">
-							A bulk-upload must have a valid email address in the
+							A bulk-upload CSV must have a valid email address in the
 							proposal_submitter_email address column.
 						</p>
 					</template>
 					<template #content>
 						<FileUploadInput
+							id="bulk-upload-file-input"
+							accept=".csv"
 							:model-value="props.bulkUpload"
 							@update:model-value="
 								(value: File | null | undefined) =>
@@ -84,8 +88,33 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 						>
 							<template #header>Choose File</template>
 							<template #instructions>
-								Drag and drop a CSV file into the box above, or click it to use
-								the file picker.
+								Click the button to use the file picker.
+							</template>
+						</FileUploadInput>
+					</template>
+				</PanelSection>
+				<PanelSection>
+					<template #header>
+						<h3>Base Field File Attachments (Optional)</h3>
+						<p class="text-color-gray-medium-dark">
+							A zip file containing the file attachments for basefields. The
+							bulk upload CSV file must refer to the files by their relative
+							path from the root of the zip file.
+						</p>
+					</template>
+					<template #content>
+						<FileUploadInput
+							id="attachments-file-input"
+							accept=".zip"
+							:model-value="props.attachmentsUpload"
+							@update:model-value="
+								(value: File | null | undefined) =>
+									emit('update:attachments-upload', value ?? null)
+							"
+						>
+							<template #header>Choose Attachments File</template>
+							<template #instructions>
+								Click the button to use the file picker.
 							</template>
 						</FileUploadInput>
 					</template>

--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -13,7 +13,7 @@ import type {
 	UserBundle,
 } from '@pdc/sdk';
 
-type fileUploadResponse = ModelFile & {
+export type FileUploadResponse = ModelFile & {
 	presignedPost: PresignedPost;
 };
 
@@ -38,7 +38,7 @@ export function useSystemSource(): ReturnType<typeof usePdcApi<Source>> {
 }
 
 export const useFileUploadCallback = () => {
-	const api = usePdcCallbackApi<fileUploadResponse>('/files');
+	const api = usePdcCallbackApi<FileUploadResponse>('/files');
 	return async (params: WritableModelFile) =>
 		await api({
 			method: 'POST',

--- a/packages/components/src/components/DataInputs/FileUploadInput.vue
+++ b/packages/components/src/components/DataInputs/FileUploadInput.vue
@@ -4,7 +4,7 @@
 			<template #header><slot name="header"></slot></template>
 		</InputHeader>
 
-		<label for="file-input" class="file-upload-area">
+		<label :for="props.id" class="file-upload-area">
 			<div v-if="!file" class="upload-text">Select a file to upload</div>
 			<div v-else class="uploaded-file">
 				<span class="file-name">{{ file.name }}</span>
@@ -12,10 +12,10 @@
 			</div>
 		</label>
 		<input
-			id="file-input"
+			:id="props.id"
 			class="hidden-input"
 			type="file"
-			accept=".csv"
+			:accept="props.accept"
 			@change="handleFileSelect"
 		/>
 
@@ -28,6 +28,11 @@
 <script setup lang="ts">
 import InputHeader from './InputHeader.vue';
 import InputInstructions from './InputInstructions.vue';
+
+const props = defineProps<{
+	accept?: string;
+	id: string;
+}>();
 
 const file = defineModel<File | null>();
 

--- a/packages/components/src/components/Panel/PanelSection.vue
+++ b/packages/components/src/components/Panel/PanelSection.vue
@@ -22,7 +22,10 @@
 .panel-section-content {
 	flex: 1;
 	width: 50%;
-	margin-top: 0;
+}
+
+.panel-section-header {
+	margin-right: var(--fixed-spacing--2x);
 }
 
 .panel-section-header :deep(h3) {

--- a/packages/components/src/stories/FileUploadInput.stories.ts
+++ b/packages/components/src/stories/FileUploadInput.stories.ts
@@ -10,6 +10,16 @@ import {
 const meta = {
 	component: FileUploadInput,
 	tags: ['autodocs'],
+	argTypes: {
+		id: {
+			control: 'text',
+			description: 'Unique ID for the file input element',
+		},
+		accept: {
+			control: 'text',
+			description: 'File types to accept (e.g., ".csv", ".zip", "image/*")',
+		},
+	},
 } satisfies Meta<typeof FileUploadInput>;
 
 export default meta;
@@ -17,6 +27,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+	args: {
+		id: 'default-file-input',
+	},
 	render: (args) => ({
 		components: {
 			FileUploadInput,
@@ -25,12 +38,18 @@ export const Default: Story = {
 			return { args };
 		},
 		template: `
-					<FileUploadInput/>
-				`,
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			/>
+		`,
 	}),
 };
 
 export const WithHeader: Story = {
+	args: {
+		id: 'header-file-input',
+	},
 	render: (args) => ({
 		components: {
 			FileUploadInput,
@@ -39,17 +58,22 @@ export const WithHeader: Story = {
 			return { args };
 		},
 		template: `
-					<FileUploadInput>
-    <template #file-upload-header>
-        <h4>File Upload Header</h4>
-    </template>
-
-					</FileUploadInput>
-				`,
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			>
+				<template #header>
+					<h4>Choose Your File</h4>
+				</template>
+			</FileUploadInput>
+		`,
 	}),
 };
 
 export const WithInstructions: Story = {
+	args: {
+		id: 'instructions-file-input',
+	},
 	render: (args) => ({
 		components: {
 			FileUploadInput,
@@ -58,18 +82,22 @@ export const WithInstructions: Story = {
 			return { args };
 		},
 		template: `
-					<FileUploadInput>
-
-    <template #file-upload-instructions>
-        <p>File Upload Instructions</p>
-    </template>
-
-					</FileUploadInput>
-				`,
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			>
+				<template #instructions>
+					<p>Drag and drop a file or click to browse. Maximum file size: 10MB.</p>
+				</template>
+			</FileUploadInput>
+		`,
 	}),
 };
 
 export const WithHeaderAndInstructions: Story = {
+	args: {
+		id: 'full-file-input',
+	},
 	render: (args) => ({
 		components: {
 			FileUploadInput,
@@ -78,19 +106,81 @@ export const WithHeaderAndInstructions: Story = {
 			return { args };
 		},
 		template: `
-					<FileUploadInput>
-    <template #file-upload-header>
-        <h4>File Upload Header</h4>
-    </template>
-    <template #file-upload-instructions>
-        <p>File Upload Instructions</p>
-    </template>
-					</FileUploadInput>
-				`,
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			>
+				<template #header>
+					<h4>Upload Your Document</h4>
+				</template>
+				<template #instructions>
+					<p>Drag and drop a file or click to browse. Accepted formats: PDF, DOCX, TXT.</p>
+				</template>
+			</FileUploadInput>
+		`,
+	}),
+};
+
+export const WithAcceptFilter: Story = {
+	args: {
+		id: 'csv-file-input',
+		accept: '.csv',
+	},
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			>
+				<template #header>
+					<h4>Upload CSV File</h4>
+				</template>
+				<template #instructions>
+					<p>Only CSV files are accepted.</p>
+				</template>
+			</FileUploadInput>
+		`,
+	}),
+};
+
+export const ZipFileUpload: Story = {
+	args: {
+		id: 'zip-file-input',
+		accept: '.zip',
+	},
+	render: (args) => ({
+		components: {
+			FileUploadInput,
+		},
+		setup() {
+			return { args };
+		},
+		template: `
+			<FileUploadInput
+				:id="args.id"
+				:accept="args.accept"
+			>
+				<template #header>
+					<h4>Upload ZIP Archive</h4>
+				</template>
+				<template #instructions>
+					<p>Upload a ZIP file containing your attachments.</p>
+				</template>
+			</FileUploadInput>
+		`,
 	}),
 };
 
 export const InPanel: Story = {
+	args: {
+		id: 'panel-file-input',
+	},
 	render: (args) => ({
 		components: {
 			FileUploadInput,
@@ -103,28 +193,91 @@ export const InPanel: Story = {
 			return { args };
 		},
 		template: `
-		<PanelComponent padded>
-		<PanelHeader>
-			<h1>Upload Data</h1>
-		</PanelHeader>
-		<PanelBody variant="data-panel-padded">
-			<PanelSection>
-				<template #header>
-					<h3>File Upload Section Header</h3>
-				</template>
-				<template #content>
-					<FileUploadInput>
-						<template #file-upload-header>
-							<h4>File Upload Header</h3>
+			<PanelComponent padded>
+				<PanelHeader>
+					<h1>Upload Data</h1>
+				</PanelHeader>
+				<PanelBody variant="data-panel-padded">
+					<PanelSection>
+						<template #header>
+							<h3>File Upload Section Header</h3>
 						</template>
-						<template #file-upload-instructions>
-							<p>File Upload Instructions</p>
+						<template #content>
+							<FileUploadInput
+								:id="args.id"
+								:accept="args.accept"
+							>
+								<template #header>
+									<h4>Choose File</h4>
+								</template>
+								<template #instructions>
+									<p>Select a CSV file to upload your data.</p>
+								</template>
+							</FileUploadInput>
 						</template>
-					</FileUploadInput>
-				</template>
-			</PanelSection>
-		</PanelBody>
-	</PanelComponent>
-				`,
+					</PanelSection>
+				</PanelBody>
+			</PanelComponent>
+		`,
+	}),
+};
+
+export const MultipleInputsInPanel: Story = {
+	args: {
+		id: 'multiple-inputs-example',
+	},
+	render: () => ({
+		components: {
+			FileUploadInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelSection,
+		},
+		template: `
+			<PanelComponent padded>
+				<PanelHeader>
+					<h1>Upload Multiple Files</h1>
+				</PanelHeader>
+				<PanelBody variant="data-panel-padded">
+					<PanelSection>
+						<template #header>
+							<h3>Main Data File</h3>
+						</template>
+						<template #content>
+							<FileUploadInput
+								id="main-data-file"
+								accept=".csv"
+							>
+								<template #header>
+									<h4>Choose CSV File</h4>
+								</template>
+								<template #instructions>
+									<p>Upload your main data CSV file.</p>
+								</template>
+							</FileUploadInput>
+						</template>
+					</PanelSection>
+					<PanelSection>
+						<template #header>
+							<h3>Attachments Archive (Optional)</h3>
+						</template>
+						<template #content>
+							<FileUploadInput
+								id="attachments-archive-file"
+								accept=".zip"
+							>
+								<template #header>
+									<h4>Choose ZIP Archive</h4>
+								</template>
+								<template #instructions>
+									<p>Upload a ZIP file containing attachments.</p>
+								</template>
+							</FileUploadInput>
+						</template>
+					</PanelSection>
+				</PanelBody>
+			</PanelComponent>
+		`,
 	}),
 };


### PR DESCRIPTION
This commit adds basefield file-attachment handling for the bulkuploader, in the form of a new file upload panel in the bulkUploader component. It also fixes a duplicate id error in the file upload component, and splits up the functionality of the addBulkUpload handler (now that we're adding another layer of complexity).

Closes #1101 