### PR TITLE
Ignore major Storybook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - 'version-update:semver-major'
+      - dependency-name: '@storybook/*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'storybook'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint-plugin-storybook'
+        update-types:
+          - 'version-update:semver-major'
 
     groups:
       storybook:


### PR DESCRIPTION
This PR stops Dependabot from bumping storybook (and related dependencies) to a version that only supports ESM