### PR TITLE
1068 implement table sorting [2/??]: Adjust column helper typing, add <EditIconLink/>

### DIFF
--- a/apps/admin-interface/src/views/BaseFieldsView.vue
+++ b/apps/admin-interface/src/views/BaseFieldsView.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="tsx">
 import {
 	PanelComponent,
 	PanelBody,
@@ -6,16 +6,15 @@ import {
 	PanelHeaderAction,
 	PanelHeaderActionsWrapper,
 	DataTable,
-	textColumn,
-	linkIconColumn,
+	EditIconLink,
+	createColumnHelper,
 } from '@pdc/components';
 import { RouterLink } from 'vue-router';
-import { PlusIcon, PencilSquareIcon } from '@heroicons/vue/24/outline';
-import { onMounted, ref, computed } from 'vue';
+import { PlusIcon } from '@heroicons/vue/24/outline';
+import { onMounted, ref, computed, h } from 'vue';
 import { useBaseFields } from '../pdc-api';
 import { getLogger, dateCompare } from '@pdc/utilities';
 import type { BaseField } from '@pdc/sdk';
-import type { ColumnDef } from '@tanstack/vue-table';
 
 const logger = getLogger('<BaseFieldsView>');
 
@@ -30,24 +29,20 @@ const baseFieldsArray = computed(() => {
 	);
 });
 
-const columns: Array<ColumnDef<BaseField>> = [
-	textColumn<BaseField>('label', 'Label'),
-	textColumn<BaseField>('description', 'Description'),
-	textColumn<BaseField>('shortCode', 'Short code'),
-	textColumn<BaseField>('dataType', 'Data type'),
-	textColumn<BaseField>('category', 'Category'),
-	{
-		accessorKey: 'valueRelevanceHours',
-		header: 'Relevance Duration (hours)',
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- valueRelevanceHours is known to be a number from the API
-		cell: (info) => String(info.getValue() as number),
-	},
-	linkIconColumn<BaseField>('edit', '', {
-		to: (row) => `/basefields/${row.shortCode}`,
-		icon: PencilSquareIcon,
-		linkClass: 'pencil-icon',
-		iconClass: 'icon text-black',
+const columnHelper = createColumnHelper<BaseField>();
+
+const columns = [
+	columnHelper.text('label', 'Label'),
+	columnHelper.text('description', 'Description'),
+	columnHelper.text('shortCode', 'Short code'),
+	columnHelper.text('dataType', 'Data type'),
+	columnHelper.text('category', 'Category'),
+	columnHelper.text('valueRelevanceHours', 'Relevance Duration (hours)', {
+		cell: (info) => String(info.getValue()),
 	}),
+	columnHelper.icon('edit', '', (row) =>
+		h(EditIconLink, { to: `/basefields/${row.shortCode}` }, 'Edit'),
+	),
 ];
 
 onMounted(async () => {
@@ -99,10 +94,6 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-.text-black {
-	color: var(--color--black);
-}
-
 :deep(.pencil-icon) {
 	display: flex;
 	align-items: center;

--- a/apps/bulk-uploader/src/components/BaseFieldsTable.vue
+++ b/apps/bulk-uploader/src/components/BaseFieldsTable.vue
@@ -4,11 +4,10 @@ import {
 	PanelHeader,
 	PanelBody,
 	DataTable,
-	textColumn,
+	createColumnHelper,
 } from '@pdc/components';
 import { BaseField } from '@pdc/sdk';
 import { computed } from 'vue';
-import type { ColumnDef } from '@tanstack/vue-table';
 
 export interface BaseFieldsTableProps {
 	baseFields: BaseField[] | null;
@@ -26,12 +25,14 @@ const publicBaseFields = computed(
 		) ?? [],
 );
 
-const columns: Array<ColumnDef<BaseField>> = [
-	textColumn<BaseField>('label', 'Label'),
-	textColumn<BaseField>('description', 'Description'),
-	textColumn<BaseField>('shortCode', 'Short code'),
-	textColumn<BaseField>('dataType', 'Data type'),
-	textColumn<BaseField>('category', 'Category'),
+const columnHelper = createColumnHelper<BaseField>();
+
+const columns = [
+	columnHelper.text('label', 'Label'),
+	columnHelper.text('description', 'Description'),
+	columnHelper.text('shortCode', 'Short code'),
+	columnHelper.text('dataType', 'Data type'),
+	columnHelper.text('category', 'Category'),
 ];
 </script>
 

--- a/packages/components/src/components/Table/DataTable.vue
+++ b/packages/components/src/components/Table/DataTable.vue
@@ -14,7 +14,8 @@ import { ref, computed } from 'vue';
 
 export interface DataTableProps<TData> {
 	data: TData[];
-	columns: Array<ColumnDef<TData>>;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any  -- needed to accept any column definition
+	columns: Array<ColumnDef<TData, any>>;
 	className?: string;
 	truncate?: boolean;
 	enableSorting?: boolean;

--- a/packages/components/src/components/Table/EditIconLink.vue
+++ b/packages/components/src/components/Table/EditIconLink.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { PencilSquareIcon } from '@heroicons/vue/24/outline';
+
+export interface EditIconLink {
+	to: string;
+}
+
+const props = defineProps<EditIconLink>();
+</script>
+
+<template>
+	<RouterLink :to="props.to" class="pencil-icon">
+		<PencilSquareIcon class="icon text-black" />
+	</RouterLink>
+</template>
+
+<style>
+.text-black {
+	color: var(--color--black);
+}
+
+.icon-link,
+.pencil-icon {
+	color: inherit;
+	text-decoration: none;
+	padding-left: 50px;
+}
+
+.icon-link:visited,
+.pencil-icon:visited {
+	color: inherit;
+}
+
+.icon-link:hover,
+.pencil-icon:hover {
+	color: inherit;
+}
+</style>

--- a/packages/components/src/components/Table/columnHelpers.ts
+++ b/packages/components/src/components/Table/columnHelpers.ts
@@ -1,138 +1,122 @@
-import type { ColumnDef } from '@tanstack/vue-table';
-import { h, type Component } from 'vue';
-import { RouterLink } from 'vue-router';
+import type {
+	AccessorKeyColumnDef,
+	DeepKeys,
+	DeepValue,
+	IdentifiedColumnDef,
+	RowData,
+	DisplayColumnDef,
+	CellContext,
+} from '@tanstack/vue-table';
 
 const DEFAULT_ACTION_COLUMN_SIZE = 100;
 const DEFAULT_ICON_ACTION_COLUMN_SIZE = 60;
 
-export function createColumnHelper<TData>(): {
-	accessor: <TAccessor extends keyof TData & string>(
+interface ColumnHelper<TData extends RowData> {
+	accessor: <
+		TAccessor extends DeepKeys<TData>,
+		TValue extends DeepValue<TData, TAccessor>,
+	>(
 		accessor: TAccessor,
-		column: Omit<ColumnDef<TData, TData[TAccessor]>, 'accessorKey'>,
-	) => ColumnDef<TData, TData[TAccessor]>;
-	display: (column: ColumnDef<TData>) => ColumnDef<TData>;
-} {
+		header: string,
+		options?: Omit<
+			IdentifiedColumnDef<TData, TValue>,
+			'accessorKey' | 'header'
+		>,
+	) => AccessorKeyColumnDef<TData, TValue>;
+
+	text: <
+		TAccessor extends DeepKeys<TData>,
+		TValue extends DeepValue<TData, TAccessor>,
+	>(
+		accessor: TAccessor,
+		header: string,
+		options?: Omit<
+			IdentifiedColumnDef<TData, TValue>,
+			'accessorKey' | 'header'
+		> & { cell?: (info: CellContext<TData, TValue>) => string },
+	) => AccessorKeyColumnDef<TData, TValue>;
+
+	display: (
+		id: string,
+		header: string,
+		options?: Omit<DisplayColumnDef<TData>, 'id' | 'header'>,
+	) => DisplayColumnDef<TData>;
+
+	action: (
+		id: string,
+		header: string,
+		cell: (row: TData) => unknown,
+		options?: {
+			size?: number;
+			minSize?: number;
+			maxSize?: number;
+		},
+	) => DisplayColumnDef<TData>;
+
+	icon: (
+		id: string,
+		header: string,
+		cell: (row: TData) => unknown,
+		options?: {
+			size?: number;
+		},
+	) => DisplayColumnDef<TData>;
+}
+
+export function createColumnHelper<
+	TData extends RowData,
+>(): ColumnHelper<TData> {
 	return {
-		accessor: <TAccessor extends keyof TData & string>(
-			accessor: TAccessor,
-			column: Omit<ColumnDef<TData, TData[TAccessor]>, 'accessorKey'>,
-		): ColumnDef<TData, TData[TAccessor]> => ({
+		accessor: (accessor, header, options) => ({
+			...options,
+			header,
 			accessorKey: accessor,
-			...column,
 		}),
 
-		display: (column: ColumnDef<TData>): ColumnDef<TData> => column,
-	};
-}
-
-export function textColumn<TData>(
-	accessor: keyof TData & string,
-	header: string,
-	options?: {
-		enableSorting?: boolean;
-		enableResizing?: boolean;
-		size?: number;
-		minSize?: number;
-		maxSize?: number;
-	},
-): ColumnDef<TData> {
-	return {
-		accessorKey: accessor,
-		header,
-		cell: (info) => {
-			const value = info.getValue();
-			if (value === null || value === undefined) {
+		text: (accessor, header, options) => ({
+			cell: (info) => {
+				const value = info.getValue();
+				if (value === null || value === undefined) {
+					return '';
+				}
+				if (
+					typeof value === 'string' ||
+					typeof value === 'number' ||
+					typeof value === 'boolean'
+				) {
+					return String(value);
+				}
 				return '';
-			}
-			if (
-				typeof value === 'string' ||
-				typeof value === 'number' ||
-				typeof value === 'boolean'
-			) {
-				return String(value);
-			}
-			return '';
-		},
-		enableSorting: options?.enableSorting ?? true,
-		enableResizing: options?.enableResizing ?? true,
-		size: options?.size,
-		minSize: options?.minSize,
-		maxSize: options?.maxSize,
-	};
-}
+			},
+			...options,
+			header,
+			accessorKey: accessor,
+		}),
 
-export function componentColumn<TData>(
-	accessor: keyof TData & string,
-	header: string,
-	component: unknown,
-	options?: {
-		enableSorting?: boolean;
-		enableResizing?: boolean;
-		size?: number;
-		minSize?: number;
-		maxSize?: number;
-	},
-): ColumnDef<TData> {
-	return {
-		accessorKey: accessor,
-		header,
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/consistent-type-assertions -- Component typing is intentionally flexible
-		cell: (info) => h(component as never, { value: info.getValue() } as never),
-		enableSorting: options?.enableSorting ?? false,
-		enableResizing: options?.enableResizing ?? true,
-		size: options?.size,
-		minSize: options?.minSize,
-		maxSize: options?.maxSize,
-	};
-}
+		display: (id, header, options) => ({
+			...options,
+			id,
+			header,
+		}),
 
-export function actionColumn<TData>(
-	id: string,
-	header: string,
-	cell: (row: TData) => unknown,
-	options?: {
-		size?: number;
-		minSize?: number;
-		maxSize?: number;
-	},
-): ColumnDef<TData> {
-	return {
-		id,
-		header,
-		cell: (info) => cell(info.row.original),
-		enableSorting: false,
-		enableResizing: options?.size === undefined,
-		size: options?.size ?? DEFAULT_ACTION_COLUMN_SIZE,
-		minSize: options?.minSize,
-		maxSize: options?.maxSize,
-	};
-}
+		action: (id, header, cell, options) => ({
+			id,
+			header,
+			cell: (info) => cell(info.row.original),
+			enableSorting: false,
+			enableResizing: options?.size === undefined,
+			size: options?.size ?? DEFAULT_ACTION_COLUMN_SIZE,
+			minSize: options?.minSize,
+			maxSize: options?.maxSize,
+		}),
 
-export function linkIconColumn<TData>(
-	id: string,
-	header: string,
-	options: {
-		to: (row: TData) => string;
-		icon: Component;
-		size?: number;
-		linkClass?: string;
-		iconClass?: string;
-	},
-): ColumnDef<TData> {
-	return {
-		id,
-		header,
-		cell: (info) =>
-			h(
-				RouterLink,
-				{
-					to: options.to(info.row.original),
-					class: options.linkClass ?? 'icon-link',
-				},
-				() => h(options.icon, { class: options.iconClass ?? 'icon' }),
-			),
-		enableSorting: false,
-		enableResizing: false,
-		size: options.size ?? DEFAULT_ICON_ACTION_COLUMN_SIZE,
+		icon: (id, header, cell, options) => ({
+			id,
+			header,
+			cell: (info) => cell(info.row.original),
+			enableSorting: false,
+			enableResizing: false,
+			size: options?.size ?? DEFAULT_ICON_ACTION_COLUMN_SIZE,
+		}),
 	};
 }

--- a/packages/components/src/components/Table/index.ts
+++ b/packages/components/src/components/Table/index.ts
@@ -1,5 +1,6 @@
 import DataTable from './DataTable.vue';
+import EditIconLink from './EditIconLink.vue';
 
-export { DataTable };
+export { DataTable, EditIconLink };
 
 export * from './columnHelpers';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -27,10 +27,7 @@ export {
 
 export {
 	DataTable,
-	textColumn,
-	actionColumn,
-	linkIconColumn,
-	componentColumn,
+	EditIconLink,
 	createColumnHelper,
 } from './components/Table';
 

--- a/packages/components/src/stories/DataTable.stories.ts
+++ b/packages/components/src/stories/DataTable.stories.ts
@@ -1,6 +1,5 @@
-import { DataTable } from '../components/Table';
-import { textColumn, actionColumn } from '../components/Table/columnHelpers';
 import { h } from 'vue';
+import { createColumnHelper, DataTable } from '../components/Table';
 
 interface Person {
 	id: string;
@@ -64,17 +63,19 @@ const sampleData: Person[] = [
 	},
 ];
 
+const columnHelper = createColumnHelper<Person>();
+
 const basicColumns = [
-	textColumn<Person>('firstName', 'First Name'),
-	textColumn<Person>('lastName', 'Last Name'),
-	textColumn<Person>('email', 'Email'),
-	textColumn<Person>('age', 'Age', { size: AGE_COLUMN_SIZE }),
-	textColumn<Person>('status', 'Status', { size: STATUS_COLUMN_SIZE }),
+	columnHelper.text('firstName', 'First Name'),
+	columnHelper.text('lastName', 'Last Name'),
+	columnHelper.text('email', 'Email'),
+	columnHelper.text('age', 'Age', { size: AGE_COLUMN_SIZE }),
+	columnHelper.text('status', 'Status', { size: STATUS_COLUMN_SIZE }),
 ];
 
 const columnsWithActions = [
 	...basicColumns,
-	actionColumn<Person>(
+	columnHelper.action(
 		'actions',
 		'Actions',
 		(row) => {


### PR DESCRIPTION
This is a PR that ladders on @hminsky2002's #1253 to make a couple suggestions. Here's how I got here:
1. I tried to regain the typing characteristics of TanStack Table's built in [column helpers](https://tanstack.com/table/latest/docs/guide/column-defs#column-helpers) by borrowing more heavily from their design, reverting to a curried factory function called `createColumnHelpers` that returns several helpers instead of the plain function approach. The goal here was for `.getValue()` in the `cell` rendering method of the column definitions to return a specific type drawn from the relevant column to obviate the need to cast the value, and that worked.
2. ~~I experimented with using [Vue's JSX support](https://vuejs.org/guide/extras/render-function.html#render-functions-jsx) in the column definitions to obviate the need to use the slightly opaque `h` function style for rendering.~~ (Update: Pull this out to solve an ESLint issue.)
3. In the process, I broke the way the link icon column helper worked, but concluded a better way to encapsulate that might be in a component, so I made a component for it instead.

@hminsky2002 See what you think. I don't promise it's all perfect, but I think I achieved what I wanted to here.