### PR TITLE
Add applicationFormId Selector to Bulk Uploader

### DIFF
--- a/apps/bulk-uploader/src/components/BulkUploader.vue
+++ b/apps/bulk-uploader/src/components/BulkUploader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FunderBundle, SourceBundle } from '@pdc/sdk';
+import type { ApplicationFormBundle, SourceBundle } from '@pdc/sdk';
 import {
 	PanelComponent,
 	PanelBody,
@@ -21,10 +21,9 @@ const props = defineProps<{
 	bulkUpload: File | null;
 	attachmentsUpload: File | null;
 	sourceId: string | null;
-	funderShortCode: string | null;
+	applicationFormId: string | null;
 	sources: SourceBundle | null;
-	funders: FunderBundle | null;
-	defaultFunderShortCode: string;
+	applicationForms: ApplicationFormBundle | null;
 	handleBulkUpload: (file: File, attachmentsFile: File | null) => Promise<void>;
 }>();
 
@@ -32,7 +31,7 @@ const emit = defineEmits<{
 	'update:bulk-upload': [file: File | null];
 	'update:attachments-upload': [file: File | null];
 	'update:source-id': [sourceId: string | null];
-	'update:funder-short-code': [funderShortCode: string | null];
+	'update:application-form-id': [applicationFormId: string | null];
 }>();
 
 const logger = getLogger('BulkUploader');
@@ -154,22 +153,21 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 							</template>
 						</SelectInput>
 						<SelectInput
-							:model-value="props.funderShortCode"
+							:model-value="props.applicationFormId"
 							:options="
-								props.funders?.entries.map((funder) => ({
-									label: funder.name,
-									value: funder.shortCode,
+								props.applicationForms?.entries.map((form) => ({
+									label: form.id.toString(),
+									value: form.id.toString(),
 								}))
 							"
 							@update:model-value="
 								(value: string | null | undefined) =>
-									emit('update:funder-short-code', value ?? null)
+									emit('update:application-form-id', value ?? null)
 							"
 						>
-							<template #header>Funder</template>
+							<template #header>Application Form</template>
 							<template #instructions>
-								If blank, the system funder shortcode will be used (default is
-								`{{ defaultFunderShortCode }}`)
+								Select the application form associated with this bulk upload.
 							</template>
 						</SelectInput>
 					</template>

--- a/apps/bulk-uploader/src/pdc-api.ts
+++ b/apps/bulk-uploader/src/pdc-api.ts
@@ -10,6 +10,7 @@ import type {
 	SourceBundle,
 	FunderBundle,
 	BaseField,
+	ApplicationFormBundle,
 } from '@pdc/sdk';
 
 export type FileUploadResponse = ModelFile & {
@@ -118,6 +119,19 @@ export function useBaseFields(
 ): ReturnType<typeof usePdcApi<BaseField[]>> {
 	return usePdcApi<BaseField[]>(
 		'/baseFields',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useApplicationForms(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<ApplicationFormBundle>> {
+	return usePdcApi<ApplicationFormBundle>(
+		'/applicationForms',
 		new URLSearchParams({
 			_page: page.toString(),
 			_count: count.toString(),

--- a/apps/bulk-uploader/src/views/AddDataView.vue
+++ b/apps/bulk-uploader/src/views/AddDataView.vue
@@ -7,8 +7,8 @@ import {
 	useRegisterBulkUploadCallback,
 	uploadUsingPresignedPost,
 	useSources,
-	useFunders,
 	useBaseFields,
+	useApplicationForms,
 } from '../pdc-api';
 import { getLogger } from '@pdc/utilities';
 import BulkUploader from '../components/BulkUploader.vue';
@@ -22,10 +22,10 @@ const bulkUpload = ref<File | null>(null);
 const attachmentsUpload = ref<File | null>(null);
 
 const sourceId = ref<string | null>(null);
-const funderShortCode = ref<string | null>(null);
+const applicationFormId = ref<string | null>(null);
 
 const { data: sources } = useSources();
-const { data: funders } = useFunders();
+const { data: applicationForms } = useApplicationForms();
 
 const { data: systemSource, fetchData: fetchSystemSource } = useSystemSource();
 const { data: baseFields, fetchData: fetchBaseFields } = useBaseFields();
@@ -33,8 +33,6 @@ const isLoading = ref(true);
 
 const createPdcFile = useFileUploadCallback();
 const registerBulkUpload = useRegisterBulkUploadCallback();
-
-const defaultFunderShortCode = 'pdc';
 
 const getMimeType = (file: File): string =>
 	file.type === '' ? 'application/octet-stream' : file.type;
@@ -81,7 +79,6 @@ const handleBulkUpload = async (
 	const bulkUploadResult = await registerBulkUpload({
 		proposalsDataFileId: proposalsDataFile.id,
 		sourceId: getSelectedSourceId(),
-		funderShortCode: funderShortCode.value ?? defaultFunderShortCode,
 		/* @ts-expect-error  -- The bulk upload task should be typed as null, but is coming through as undefined due to an sdk issue. */
 		attachmentsArchiveFileId: attachmentsDataFile?.id ?? null,
 		attachmentsArchiveFile: null,
@@ -97,11 +94,10 @@ const handleBulkUpload = async (
 		v-model:bulk-upload="bulkUpload"
 		v-model:attachments-upload="attachmentsUpload"
 		v-model:source-id="sourceId"
-		v-model:funder-short-code="funderShortCode"
+		v-model:application-form-id="applicationFormId"
 		:sources="sources"
-		:funders="funders"
 		:handle-bulk-upload="handleBulkUpload"
-		:default-funder-short-code="defaultFunderShortCode"
+		:application-forms="applicationForms"
 	/>
 	<BaseFieldsTable :base-fields="baseFields" :is-loading="isLoading" />
 </template>


### PR DESCRIPTION
This commit is intertwined with pdc service issue 2063 and the corresponding pull request (https://github.com/PhilanthropyDataCommons/service/pull/2198), which rework our bulk upload flow to no longer create application forms on creation, but rather expect linkage to existing application forms. The commit itself adds an additional selector to the bulk uploader component/form for selecting application form by ID.

Closes #1308 