### PR TITLE
Improving column resizing

### DIFF
--- a/packages/components/src/components/Table/columnHelpers.ts
+++ b/packages/components/src/components/Table/columnHelpers.ts
@@ -9,7 +9,7 @@ import type {
 } from '@tanstack/vue-table';
 
 const DEFAULT_ACTION_COLUMN_SIZE = 100;
-const DEFAULT_ICON_ACTION_COLUMN_SIZE = 60;
+const DEFAULT_ICON_ACTION_COLUMN_SIZE = 40;
 
 interface ColumnHelper<TData extends RowData> {
 	accessor: <


### PR DESCRIPTION
This PR iterates on our existing column resizing and responds to feedback in #1309 to make the column resizing more natural and responsive! Specifically, it allows for the entire data table to extend past the default screen size, instead of conforming all resizing to still fit within the data table max width. 

Closes #1309 