### PR TITLE
Fix typing of application form id for deployment

### DIFF
--- a/apps/bulk-uploader/src/views/AddDataView.vue
+++ b/apps/bulk-uploader/src/views/AddDataView.vue
@@ -83,6 +83,10 @@ const handleBulkUpload = async (
 		attachmentsArchiveFileId: attachmentsDataFile?.id ?? null,
 		attachmentsArchiveFile: null,
 		logs: [],
+		applicationFormId:
+			applicationFormId.value !== null && applicationFormId.value !== ''
+				? Number(applicationFormId.value)
+				: null,
 	});
 
 	await router.push(`/bulk-uploads/${bulkUploadResult.id}`);


### PR DESCRIPTION
This is a quick fix wherein the typing of the application formid needed to be more explicit.