### PR TITLE
Add WordPress publishing workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,30 @@
+name: Publish to WordPress
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**/*.md'
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force republish all posts'
+        default: 'true'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Publish to WordPress
+        uses: OpenTechStrategies/wp-post-gfm@main
+        with:
+          directory: 'docs'
+          default_status: 'publish'
+        env:
+          WP_URL: ${{ secrets.WP_URL }}
+          WP_USERNAME: ${{ secrets.WP_USERNAME }}
+          WP_APP_PASSWORD: ${{ secrets.WP_APP_PASSWORD }}


### PR DESCRIPTION
See https://github.com/PhilanthropyDataCommons/service/pull/2246

Addresses https://github.com/PhilanthropyDataCommons/meta/issues/137

Add workflow to publish .md files on push to WordPress site. Docs will be categorized based on file path so if we one day have more docs here, a directory structure will help that. We can also [add categories in front matter](https://github.com/OpenTechStrategies/wp-post-gfm/blob/da9252cf0c020868a9581a44db1ae8f7973637ed/src/index.js#L357), as below at the top of any Markdown file.

```
---
categories: cat1, cat2, data
---
```