### PR TITLE
Require manual major eslint bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
       - dependency-name: 'eslint-plugin-storybook'
         update-types:
           - 'version-update:semver-major'
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
 
     groups:
       storybook:


### PR DESCRIPTION
This PR disables automatic major version bumps to eslint, since the tend to result in broken CI for a while as the rest of the community takes weeks / months to add support.