### PR TITLE
Fix `format`

### DIFF
--- a/apps/admin-interface/.storybook/preview.ts
+++ b/apps/admin-interface/.storybook/preview.ts
@@ -5,7 +5,7 @@ const preview: Preview = {
 	parameters: {
 		controls: {
 			matchers: {
-				color: /(background|color)$/i,
+				color: /(?:background|color)$/i,
 				date: /Date$/i,
 			},
 		},

--- a/apps/admin-interface/package.json
+++ b/apps/admin-interface/package.json
@@ -27,7 +27,7 @@
 		"build:app": "vue-tsc && vite build",
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
 		"lint:prettier": "prettier . --check --ignore-path ../../.gitignore",
-		"lint:eslint": "eslint ./src --report-unused-disable-directives --max-warnings 0",
+		"lint:eslint": "eslint --report-unused-disable-directives --max-warnings 0",
 		"lint:tsc": "vue-tsc --noEmit",
 		"format": "npm run format:prettier && npm run format:eslint",
 		"format:prettier": "prettier . --write  --ignore-path ../../.gitignore",

--- a/apps/admin-interface/tsconfig.json
+++ b/apps/admin-interface/tsconfig.json
@@ -12,6 +12,7 @@
 		"src/**/*.ts",
 		"src/**/*.vue",
 		"src/tests/oidc-config.ts",
-		"src/shims-vue.d.ts"
+		"src/shims-vue.d.ts",
+		".storybook/*.ts"
 	]
 }

--- a/apps/user-tools/.storybook/preview.ts
+++ b/apps/user-tools/.storybook/preview.ts
@@ -5,7 +5,7 @@ const preview: Preview = {
 	parameters: {
 		controls: {
 			matchers: {
-				color: /(background|color)$/i,
+				color: /(?:background|color)$/i,
 				date: /Date$/i,
 			},
 		},

--- a/apps/user-tools/package.json
+++ b/apps/user-tools/package.json
@@ -26,7 +26,7 @@
 		"build:app": "vue-tsc && vite build",
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
 		"lint:prettier": "prettier . --check --ignore-path ../../.gitignore",
-		"lint:eslint": "eslint ./src --report-unused-disable-directives --max-warnings 0",
+		"lint:eslint": "eslint --report-unused-disable-directives --max-warnings 0",
 		"lint:tsc": "vue-tsc --noEmit",
 		"format": "npm run format:prettier && npm run format:eslint",
 		"format:prettier": "prettier . --write  --ignore-path ../../.gitignore",

--- a/apps/user-tools/tsconfig.json
+++ b/apps/user-tools/tsconfig.json
@@ -12,6 +12,7 @@
 		"src/**/*.ts",
 		"src/**/*.vue",
 		"src/tests/oidc-config.ts",
-		"src/shims-vue.d.ts"
+		"src/shims-vue.d.ts",
+		".storybook/*.ts"
 	]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,7 @@ export default typescriptEslint.config(
 			import: eslintPluginImport,
 		},
 	},
-	{ ignores: ['**/*.d.ts', '**/coverage', '**/dist', '**/.storybook', '**/vite.config.ts', '**/vitest.config.ts'] },
+	{ ignores: ['**/*.d.ts', '**/coverage', '**/dist', '**/vite.config.ts', '**/vitest.config.ts'] },
 	{
 		files: ['**/*.{ts,vue}'],
 		languageOptions: {
@@ -71,6 +71,13 @@ export default typescriptEslint.config(
 		files: ['**/*.stories.*'],
 		rules: {
 			'import/no-anonymous-default-export': 'off',
+			'import/no-default-export': 'off',
+		},
+	},
+	{
+		// Storybook configuration files conventionally use default exports
+		files: ['**/.storybook/*.ts'],
+		rules: {
 			'import/no-default-export': 'off',
 		},
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,7 @@ export default typescriptEslint.config(
 			import: eslintPluginImport,
 		},
 	},
-	{ ignores: ['*.d.ts', '**/coverage', '**/dist'] },
+	{ ignores: ['**/*.d.ts', '**/coverage', '**/dist', '**/.storybook', '**/vite.config.ts', '**/vitest.config.ts'] },
 	{
 		files: ['**/*.{ts,vue}'],
 		languageOptions: {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
 		"lint:prettier": "prettier . --check --ignore-path ../../.gitignore",
-		"lint:eslint": "eslint ./src --report-unused-disable-directives --max-warnings 0",
+		"lint:eslint": "eslint --report-unused-disable-directives --max-warnings 0",
 		"lint:tsc": "vue-tsc --noEmit",
 		"format": "npm run format:prettier && npm run format:eslint",
 		"format:prettier": "prettier . --write  --ignore-path ../../.gitignore",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:tsc",
 		"lint:prettier": "prettier . --check --ignore-path ../../.gitignore",
-		"lint:eslint": "eslint ./src --report-unused-disable-directives --max-warnings 0",
+		"lint:eslint": "eslint --report-unused-disable-directives --max-warnings 0",
 		"lint:tsc": "vue-tsc --noEmit",
 		"test": "vitest --run",
 		"format": "npm run format:prettier && npm run format:eslint",


### PR DESCRIPTION
Our format eslint was targeting more files than our lint eslint; this fixes that and also expands the lint target to include storybook for both.


Resolves #1373 