### PR TITLE
Add create view for permissions interface

### DIFF
--- a/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
+++ b/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import {
+	PanelComponent,
+	PanelBody,
+	PanelHeader,
+	PanelHeaderActionsWrapper,
+	PanelSection,
+	BackButton,
+	RadioInput,
+	TextInput,
+	SelectInput,
+	CheckboxInput,
+	DataSubmitButton,
+	ErrorMessage,
+} from '@pdc/components';
+import { reactive, ref, computed, watch } from 'vue';
+import { getLogger } from '@pdc/utilities';
+import {
+	GRANTEE_TYPE_OPTIONS,
+	CONTEXT_ENTITY_TYPE_OPTIONS,
+	PERMISSION_VERB_OPTIONS,
+	buildPermissionGrantPayload,
+	getEntityKeyPlaceholder,
+	getScopesForContextEntityType,
+	isFormReady,
+	type PermissionGrantFormState,
+	type WritablePermissionGrantPayload,
+} from '../../permissionsHelpers';
+
+const logger = getLogger('<PermissionGrantForm>');
+
+const props = defineProps<{
+	onSubmit: (payload: WritablePermissionGrantPayload) => Promise<void>;
+	title?: string;
+	submitLabel?: string;
+	backTo?: string;
+}>();
+
+const {
+	title = 'Grant Permission',
+	submitLabel = 'Grant Permission',
+	backTo = '/permissions',
+} = props;
+
+const form = reactive<PermissionGrantFormState>({
+	granteeType: null,
+	granteeId: '',
+	contextEntityType: null,
+	entityKey: '',
+	verbs: [],
+	scope: [],
+});
+
+const hadError = ref(false);
+const errorMessage = ref('');
+
+const scopeOptions = computed(() =>
+	getScopesForContextEntityType(form.contextEntityType).map((s) => ({
+		label: s,
+		value: s,
+	})),
+);
+
+const entityKeyPlaceholder = computed(() =>
+	getEntityKeyPlaceholder(form.contextEntityType),
+);
+
+const granteeNoun = computed(() => {
+	if (form.granteeType === 'user') return 'the user';
+	if (form.granteeType === 'userGroup') return 'the group';
+	return 'the user or group';
+});
+
+watch(
+	() => form.contextEntityType,
+	(newType) => {
+		const allowed = new Set<string>(getScopesForContextEntityType(newType));
+		form.scope = form.scope.filter((s) => allowed.has(s));
+	},
+);
+
+const canSubmit = computed(() => isFormReady(form));
+
+const handleFormSubmit = async (event: Event): Promise<void> => {
+	event.preventDefault();
+	if (!canSubmit.value) return;
+	hadError.value = false;
+	errorMessage.value = '';
+	try {
+		const payload = buildPermissionGrantPayload(form);
+		await props.onSubmit(payload);
+	} catch (error) {
+		logger.error({ error }, 'Failed to submit permission grant');
+		errorMessage.value =
+			error instanceof Error
+				? error.message
+				: 'An error occurred while granting permission.';
+		hadError.value = true;
+	}
+};
+</script>
+
+<template>
+	<PanelComponent padded>
+		<PanelHeader>
+			<h1>{{ title }}</h1>
+			<PanelHeaderActionsWrapper>
+				<BackButton :to="backTo" label="Back to Permissions" />
+			</PanelHeaderActionsWrapper>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+			<form @submit="handleFormSubmit">
+				<PanelSection>
+					<template #header>
+						<h3>Grantee</h3>
+						<p class="text-color-gray-medium-dark">
+							Who do you want to give permission to?
+						</p>
+					</template>
+					<template #content>
+						<RadioInput
+							v-model="form.granteeType"
+							name="grantee-type"
+							:options="GRANTEE_TYPE_OPTIONS"
+						>
+							<template #header>Grantee type</template>
+						</RadioInput>
+						<TextInput v-model="form.granteeId">
+							<template #header>Grantee ID</template>
+							<template #instructions>
+								The Keycloak UUID for {{ granteeNoun }} (e.g.,
+								550e8400-e29b-41d4-a716-446655440000).
+							</template>
+						</TextInput>
+					</template>
+				</PanelSection>
+
+				<PanelSection>
+					<template #header>
+						<h3>Permissions</h3>
+						<p class="text-color-gray-medium-dark">
+							What do you want {{ granteeNoun }} to be able to do?
+						</p>
+					</template>
+					<template #content>
+						<CheckboxInput
+							v-model="form.verbs"
+							name="verbs"
+							:options="PERMISSION_VERB_OPTIONS"
+						>
+							<template #header>Which actions do you want to allow?</template>
+						</CheckboxInput>
+					</template>
+				</PanelSection>
+
+				<PanelSection>
+					<template #header>
+						<h3>Context</h3>
+						<p class="text-color-gray-medium-dark">
+							Which entity does this grant apply to?
+						</p>
+					</template>
+					<template #content>
+						<SelectInput
+							v-model="form.contextEntityType"
+							:options="CONTEXT_ENTITY_TYPE_OPTIONS"
+						>
+							<template #header>Entity type (required)</template>
+							<template #instructions>
+								Applies to all data with a related entity of this type.
+							</template>
+						</SelectInput>
+						<TextInput
+							v-if="form.contextEntityType !== null"
+							v-model="form.entityKey"
+						>
+							<template #header>{{ entityKeyPlaceholder }}</template>
+							<template #instructions>
+								Enter the {{ entityKeyPlaceholder.toLowerCase() }} for the
+								{{ form.contextEntityType }}.
+							</template>
+						</TextInput>
+						<CheckboxInput
+							v-if="form.contextEntityType !== null"
+							v-model="form.scope"
+							name="scope"
+							:options="scopeOptions"
+						>
+							<template #header>On which types of data?</template>
+							<template #instructions>
+								Limited to scopes valid for the selected entity type.
+							</template>
+						</CheckboxInput>
+					</template>
+				</PanelSection>
+
+				<PanelSection>
+					<template #header>
+						<h3>Ready to Grant Permission</h3>
+						<p class="text-color-gray-medium-dark">
+							{{
+								canSubmit
+									? 'All required fields have been provided.'
+									: 'Fill in grantee, context, allowed actions and scope to continue.'
+							}}
+						</p>
+					</template>
+					<template #content>
+						<DataSubmitButton :disabled="!canSubmit">
+							{{ submitLabel }}
+						</DataSubmitButton>
+						<ErrorMessage v-if="hadError" :message="errorMessage" />
+					</template>
+				</PanelSection>
+			</form>
+		</PanelBody>
+	</PanelComponent>
+</template>

--- a/apps/user-tools/src/pdc-api.ts
+++ b/apps/user-tools/src/pdc-api.ts
@@ -14,8 +14,10 @@ import type {
 	ApplicationFormBundle,
 	OpportunityBundle,
 	Opportunity,
+	PermissionGrant,
 	PermissionGrantBundle,
 } from '@pdc/sdk';
+import type { WritablePermissionGrantPayload } from './permissionsHelpers';
 
 export type FileUploadResponse = ModelFile & {
 	presignedPost: PresignedPost;
@@ -49,6 +51,19 @@ export function usePermissionGrants(
 		}),
 	);
 }
+
+export const useCreatePermissionGrantCallback = () => {
+	const api = usePdcCallbackApi<PermissionGrant>('/permissionGrants');
+	return async (params: WritablePermissionGrantPayload) =>
+		await api({
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(params),
+		});
+};
 
 export function useSystemSource(): ReturnType<typeof usePdcApi<Source>> {
 	return usePdcApi<Source>('/sources/1');

--- a/apps/user-tools/src/permissionsHelpers.ts
+++ b/apps/user-tools/src/permissionsHelpers.ts
@@ -1,8 +1,18 @@
+/**
+ * Local types and lookups for permission grants.
+ *
+ * Much of this file exists to paper over gaps in the generated `@pdc/sdk`
+ * types — see PhilanthropyDataCommons/service#2353 for the full list of
+ * SDK issues being tracked. When that lands, the reshaped types and
+ * hardcoded enum/scope tables here should fall out.
+ */
 import type { PermissionGrant } from '@pdc/sdk';
 
-// The SDK's PermissionGrant type omits grantee fields the API returns and
-// types `scope`/`verbs` as opaque empty interfaces. Reshape locally until
-// the SDK catches up.
+/**
+ * API-shaped permission grant row. The SDK's `PermissionGrant` omits
+ * grantee fields and types `scope`/`verbs` as opaque empty interfaces, so
+ * we reshape here. Tracks service#2353.
+ */
 export type PermissionGrantRow = Omit<PermissionGrant, 'scope' | 'verbs'> & {
 	scope: string[];
 	verbs: string[];
@@ -11,7 +21,27 @@ export type PermissionGrantRow = Omit<PermissionGrant, 'scope' | 'verbs'> & {
 	granteeKeycloakOrganizationId?: string | null;
 };
 
-const ENTITY_LABEL_KEYS: Record<string, keyof PermissionGrantRow> = {
+export const CONTEXT_ENTITY_TYPES = [
+	'changemaker',
+	'funder',
+	'dataProvider',
+	'opportunity',
+	'proposal',
+	'proposalVersion',
+	'applicationForm',
+	'applicationFormField',
+	'proposalFieldValue',
+	'source',
+	'bulkUpload',
+	'changemakerFieldValue',
+] as const;
+
+export type ContextEntityType = (typeof CONTEXT_ENTITY_TYPES)[number];
+
+export const CONTEXT_ENTITY_KEYS: Record<
+	ContextEntityType,
+	keyof PermissionGrantRow
+> = {
 	changemaker: 'changemakerId',
 	funder: 'funderShortCode',
 	dataProvider: 'dataProviderShortCode',
@@ -26,13 +56,191 @@ const ENTITY_LABEL_KEYS: Record<string, keyof PermissionGrantRow> = {
 	changemakerFieldValue: 'changemakerFieldValueId',
 };
 
+export const CONTEXT_ENTITY_KEY_IS_SHORT_CODE: ReadonlySet<string> = new Set([
+	'funder',
+	'dataProvider',
+]);
+
+/**
+ * Valid `scope` values per `contextEntityType`. Mirrors
+ * `contextEntityTypeScopes` in service/src/types/PermissionGrant.ts; keep
+ * in sync when the service adds or changes a context type.
+ */
+export const CONTEXT_ENTITY_SCOPES: Record<
+	ContextEntityType,
+	readonly ContextEntityType[]
+> = {
+	changemaker: [
+		'changemaker',
+		'changemakerFieldValue',
+		'proposal',
+		'proposalFieldValue',
+	],
+	funder: ['funder', 'opportunity', 'proposal', 'proposalFieldValue'],
+	dataProvider: ['dataProvider'],
+	opportunity: ['opportunity', 'proposal', 'proposalFieldValue'],
+	proposal: ['proposal', 'proposalFieldValue'],
+	proposalVersion: ['proposalVersion'],
+	applicationForm: ['applicationForm'],
+	applicationFormField: ['applicationFormField'],
+	proposalFieldValue: ['proposalFieldValue'],
+	source: ['source'],
+	bulkUpload: ['bulkUpload'],
+	changemakerFieldValue: ['changemakerFieldValue'],
+};
+
+export const PERMISSION_VERBS = [
+	'view',
+	'create',
+	'edit',
+	'delete',
+	'manage',
+] as const;
+
+export type PermissionVerb = (typeof PERMISSION_VERBS)[number];
+
+interface LabeledOption {
+	label: string;
+	value: string;
+}
+
+export const PERMISSION_VERB_OPTIONS: LabeledOption[] = [
+	{ label: 'View', value: 'view' },
+	{ label: 'Create', value: 'create' },
+	{ label: 'Edit', value: 'edit' },
+	{ label: 'Delete', value: 'delete' },
+	{ label: 'Manage', value: 'manage' },
+];
+
+export type GranteeType = 'user' | 'userGroup';
+
+export const GRANTEE_TYPE_OPTIONS: LabeledOption[] = [
+	{ label: 'User', value: 'user' },
+	{ label: 'Group', value: 'userGroup' },
+];
+
+export const CONTEXT_ENTITY_TYPE_OPTIONS: LabeledOption[] =
+	CONTEXT_ENTITY_TYPES.map((type) => ({ label: type, value: type }));
+
+export const getEntityKeyPlaceholder = (
+	contextEntityType: string | null | undefined,
+): string =>
+	typeof contextEntityType === 'string' &&
+	CONTEXT_ENTITY_KEY_IS_SHORT_CODE.has(contextEntityType)
+		? 'Entity Shortcode'
+		: 'Entity ID';
+
+export interface PermissionGrantFormState {
+	granteeType: string | null;
+	granteeId: string;
+	contextEntityType: string | null;
+	entityKey: string;
+	verbs: string[];
+	scope: string[];
+}
+
+const CONTEXT_ENTITY_TYPES_SET: ReadonlySet<string> = new Set(
+	CONTEXT_ENTITY_TYPES,
+);
+
+export const isContextEntityType = (
+	value: string | null | undefined,
+): value is ContextEntityType =>
+	typeof value === 'string' && CONTEXT_ENTITY_TYPES_SET.has(value);
+
+export const isGranteeType = (
+	value: string | null | undefined,
+): value is GranteeType => value === 'user' || value === 'userGroup';
+
+export const getScopesForContextEntityType = (
+	value: string | null | undefined,
+): readonly string[] =>
+	isContextEntityType(value) ? CONTEXT_ENTITY_SCOPES[value] : [];
+
+const MIN_ENTITY_ID = 1;
+
+/**
+ * Whether `entityKey` is a valid value for the selected `contextEntityType`.
+ * Short-code contexts (funder, dataProvider) accept any non-empty string;
+ * everything else requires a positive integer, since the backend rejects
+ * the `NaN`-serializes-as-`null` case with a cryptic error.
+ */
+export const isValidEntityKey = (
+	contextEntityType: string | null | undefined,
+	entityKey: string,
+): boolean => {
+	const trimmed = entityKey.trim();
+	if (trimmed === '') return false;
+	if (typeof contextEntityType !== 'string') return false;
+	if (CONTEXT_ENTITY_KEY_IS_SHORT_CODE.has(contextEntityType)) return true;
+	const parsed = Number(trimmed);
+	return Number.isInteger(parsed) && parsed >= MIN_ENTITY_ID;
+};
+
+export type WritablePermissionGrantPayload = {
+	contextEntityType: ContextEntityType;
+	scope: string[];
+	verbs: string[];
+} & (
+	| { granteeType: 'user'; granteeUserKeycloakUserId: string }
+	| { granteeType: 'userGroup'; granteeKeycloakOrganizationId: string }
+);
+
 export const formatEntityLabel = (row: PermissionGrantRow): string => {
-	const { [row.contextEntityType]: key } = ENTITY_LABEL_KEYS;
-	if (key === undefined) return row.contextEntityType;
+	if (!isContextEntityType(row.contextEntityType)) return row.contextEntityType;
+	const { [row.contextEntityType]: key } = CONTEXT_ENTITY_KEYS;
 	const { [key]: value } = row;
 	if (typeof value === 'number')
 		return `${row.contextEntityType} #${value.toString()}`;
 	if (typeof value === 'string' && value !== '')
 		return `${row.contextEntityType} ${value}`;
 	return row.contextEntityType;
+};
+
+const MIN_SELECTIONS = 1;
+
+export const isFormReady = (form: PermissionGrantFormState): boolean =>
+	isGranteeType(form.granteeType) &&
+	form.granteeId.trim() !== '' &&
+	isContextEntityType(form.contextEntityType) &&
+	isValidEntityKey(form.contextEntityType, form.entityKey) &&
+	form.verbs.length >= MIN_SELECTIONS &&
+	form.scope.length >= MIN_SELECTIONS;
+
+export const buildPermissionGrantPayload = (
+	form: PermissionGrantFormState,
+): WritablePermissionGrantPayload => {
+	if (
+		!isGranteeType(form.granteeType) ||
+		!isContextEntityType(form.contextEntityType)
+	) {
+		throw new Error(
+			'Cannot build permission grant payload: grantee type and context entity type are required.',
+		);
+	}
+	const { granteeType, contextEntityType } = form;
+	if (!isValidEntityKey(contextEntityType, form.entityKey)) {
+		throw new Error(`Invalid entity key for context "${contextEntityType}".`);
+	}
+	const { [contextEntityType]: contextKey } = CONTEXT_ENTITY_KEYS;
+	const contextValue = CONTEXT_ENTITY_KEY_IS_SHORT_CODE.has(contextEntityType)
+		? form.entityKey.trim()
+		: Number(form.entityKey);
+
+	const granteeId = form.granteeId.trim();
+	const grantee =
+		granteeType === 'user'
+			? { granteeType, granteeUserKeycloakUserId: granteeId }
+			: { granteeType, granteeKeycloakOrganizationId: granteeId };
+
+	const payload: Record<string, unknown> = {
+		...grantee,
+		contextEntityType,
+		[contextKey]: contextValue,
+		scope: form.scope,
+		verbs: form.verbs,
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Dynamic contextKey prevents structural typing; guards above enforce the shape at runtime.
+	return payload as unknown as WritablePermissionGrantPayload;
 };

--- a/apps/user-tools/src/views/permissions/AddPermissionView.vue
+++ b/apps/user-tools/src/views/permissions/AddPermissionView.vue
@@ -1,23 +1,20 @@
 <script setup lang="ts">
-import {
-	PanelComponent,
-	PanelBody,
-	PanelHeader,
-	PanelHeaderActionsWrapper,
-	BackButton,
-} from '@pdc/components';
+import { useRouter } from 'vue-router';
+import PermissionGrantForm from '../../components/permissions/PermissionGrantForm.vue';
+import { useCreatePermissionGrantCallback } from '../../pdc-api';
+import type { WritablePermissionGrantPayload } from '../../permissionsHelpers';
+
+const router = useRouter();
+const createPermissionGrant = useCreatePermissionGrantCallback();
+
+const handleCreate = async (
+	payload: WritablePermissionGrantPayload,
+): Promise<void> => {
+	await createPermissionGrant(payload);
+	await router.push('/permissions');
+};
 </script>
 
 <template>
-	<PanelComponent padded>
-		<PanelHeader>
-			<h1>New Permission Grant</h1>
-			<PanelHeaderActionsWrapper>
-				<BackButton to="/permissions" label="Back to permissions" />
-			</PanelHeaderActionsWrapper>
-		</PanelHeader>
-		<PanelBody variant="padded">
-			<p>Permission grant creation form coming soon.</p>
-		</PanelBody>
-	</PanelComponent>
+	<PermissionGrantForm :on-submit="handleCreate" />
 </template>

--- a/packages/components/src/components/DataInputs/CheckboxInput.vue
+++ b/packages/components/src/components/DataInputs/CheckboxInput.vue
@@ -1,0 +1,76 @@
+<template>
+	<div class="checkbox-input-container">
+		<InputHeader>
+			<template #header><slot name="header"></slot></template>
+		</InputHeader>
+		<InputInstructions>
+			<template #instructions><slot name="instructions"></slot></template>
+		</InputInstructions>
+		<fieldset>
+			<div
+				v-for="(option, index) in options"
+				:key="option.value"
+				class="checkbox-input-container"
+			>
+				<div class="checkbox-input-option">
+					<input
+						:id="`checkbox-option-${index}-${name}-${option.value}`"
+						v-model="modelValue"
+						type="checkbox"
+						:name="name"
+						:value="option.value"
+					/>
+					<label :for="`checkbox-option-${index}-${name}-${option.value}`">{{
+						option.label
+					}}</label>
+				</div>
+				<p v-if="option.description" class="text-color-gray-medium-dark">
+					{{ option.description }}
+				</p>
+			</div>
+		</fieldset>
+	</div>
+</template>
+
+<script setup lang="ts">
+import InputHeader from './InputHeader.vue';
+import InputInstructions from './InputInstructions.vue';
+
+export interface CheckboxInputProps {
+	options?: Array<{ label: string; value: string; description?: string }>;
+	name?: string;
+}
+
+const modelValue = defineModel<string[]>({ default: () => [] });
+
+const { options = [], name = 'checkbox-input' } =
+	defineProps<CheckboxInputProps>();
+</script>
+
+<style scoped>
+fieldset {
+	border: none;
+	padding: 0;
+	margin-top: 10px;
+}
+
+legend {
+	font-size: var(--font-size);
+}
+
+label {
+	font-size: 20px;
+}
+
+.checkbox-input-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
+.checkbox-input-option {
+	display: flex;
+	align-items: center;
+	gap: var(--fixed-spacing--1x);
+}
+</style>

--- a/packages/components/src/components/DataInputs/index.ts
+++ b/packages/components/src/components/DataInputs/index.ts
@@ -2,6 +2,7 @@ import FileUploadInput from './FileUploadInput.vue';
 import DataSubmitButton from './DataSubmitButton.vue';
 import SelectInput from './SelectInput.vue';
 import RadioInput from './RadioInput.vue';
+import CheckboxInput from './CheckboxInput.vue';
 import TextInput from './TextInput.vue';
 import InputHeader from './InputHeader.vue';
 import InputInstructions from './InputInstructions.vue';
@@ -11,6 +12,7 @@ export {
 	DataSubmitButton,
 	SelectInput,
 	RadioInput,
+	CheckboxInput,
 	TextInput,
 	InputHeader,
 	InputInstructions,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -38,6 +38,7 @@ export {
 	FileUploadInput,
 	SelectInput,
 	RadioInput,
+	CheckboxInput,
 	TextInput,
 	InputHeader,
 	InputInstructions,

--- a/packages/components/src/stories/CheckboxInput.stories.ts
+++ b/packages/components/src/stories/CheckboxInput.stories.ts
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { CheckboxInput } from '../components/DataInputs';
+import {
+	PanelComponent,
+	PanelHeader,
+	PanelBody,
+	PanelHeaderActionsWrapper,
+	PanelHeaderAction,
+	PanelSection,
+} from '../components/Panel';
+
+const meta = {
+	component: CheckboxInput,
+	tags: ['autodocs'],
+} satisfies Meta<typeof CheckboxInput>;
+
+export default meta;
+const checkboxOptions = [
+	{ label: 'Option 1', value: 'option1' },
+	{ label: 'Option 2', value: 'option2' },
+	{ label: 'Option 3', value: 'option3' },
+];
+
+const checkboxOptionsWithDescription = [
+	{ label: 'Option 1', value: 'option1', description: 'Option 1 description' },
+	{ label: 'Option 2', value: 'option2', description: 'Option 2 description' },
+	{ label: 'Option 3', value: 'option3', description: 'Option 3 description' },
+];
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: {
+			CheckboxInput,
+		},
+		setup() {
+			return { args, checkboxOptions };
+		},
+		template: `<CheckboxInput :options="checkboxOptions" />`,
+	}),
+};
+export const WithDescription: Story = {
+	render: (args) => ({
+		components: {
+			CheckboxInput,
+		},
+		setup() {
+			return { args, checkboxOptionsWithDescription };
+		},
+		template: `<CheckboxInput :options="checkboxOptionsWithDescription" />`,
+	}),
+};
+export const InPanel: Story = {
+	render: (args) => ({
+		components: {
+			CheckboxInput,
+			PanelComponent,
+			PanelHeader,
+			PanelBody,
+			PanelHeaderActionsWrapper,
+			PanelHeaderAction,
+			PanelSection,
+		},
+		setup() {
+			return { args, checkboxOptionsWithDescription };
+		},
+		template: `<PanelComponent padded>
+		<PanelHeader>
+			<h1>Upload Data</h1>
+		</PanelHeader>
+		<PanelBody variant="data-panel-padded">
+
+			<PanelSection>
+					<template #header>
+					<h3>Checkbox Section Header</h3>
+				</template>
+				<template #content>
+					<CheckboxInput :options="checkboxOptionsWithDescription" />
+				</template>
+			</PanelSection>
+
+		</PanelBody>
+	</PanelComponent>`,
+	}),
+};


### PR DESCRIPTION
Note: This PR currently adds a lot of patching to get around the fact that the sdk is busted for permissions. Happy to hold off on merging this while I work on https://github.com/PhilanthropyDataCommons/service/issues/2353, but I also think we could just commit to dumping every custom type interface as soon as that issue is resolved.

Closes #1365 