### PR TITLE
Add edit view and component

### DIFF
--- a/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
+++ b/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
@@ -6,6 +6,7 @@ import {
 	PanelHeaderActionsWrapper,
 	PanelSection,
 	BackButton,
+	CustomButton,
 	RadioInput,
 	TextInput,
 	SelectInput,
@@ -29,27 +30,38 @@ import {
 
 const logger = getLogger('<PermissionGrantForm>');
 
+type FormMode = 'create' | 'edit';
+
 const props = defineProps<{
+	mode: FormMode;
 	onSubmit: (payload: WritablePermissionGrantPayload) => Promise<void>;
+	initialValue?: PermissionGrantFormState;
+	onDelete?: () => Promise<void>;
 	title?: string;
 	submitLabel?: string;
 	backTo?: string;
 }>();
 
 const {
-	title = 'Grant Permission',
-	submitLabel = 'Grant Permission',
+	mode,
+	title = mode === 'edit' ? 'Edit Permission Grant' : 'Grant Permission',
+	submitLabel = mode === 'edit' ? 'Save changes' : 'Grant Permission',
 	backTo = '/permissions',
 } = props;
 
-const form = reactive<PermissionGrantFormState>({
-	granteeType: null,
-	granteeId: '',
-	contextEntityType: null,
-	entityKey: '',
-	verbs: [],
-	scope: [],
-});
+const readyHeading =
+	mode === 'edit' ? 'Ready to save' : 'Ready to Grant Permission';
+
+const form = reactive<PermissionGrantFormState>(
+	props.initialValue ?? {
+		granteeType: null,
+		granteeId: '',
+		contextEntityType: null,
+		entityKey: '',
+		verbs: [],
+		scope: [],
+	},
+);
 
 const hadError = ref(false);
 const errorMessage = ref('');
@@ -196,7 +208,7 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 
 				<PanelSection>
 					<template #header>
-						<h3>Ready to Grant Permission</h3>
+						<h3>{{ readyHeading }}</h3>
 						<p class="text-color-gray-medium-dark">
 							{{
 								canSubmit
@@ -210,6 +222,19 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 							{{ submitLabel }}
 						</DataSubmitButton>
 						<ErrorMessage v-if="hadError" :message="errorMessage" />
+					</template>
+				</PanelSection>
+
+				<PanelSection v-if="onDelete !== undefined">
+					<template #header>
+						<h3>Remove Permission</h3>
+					</template>
+					<template #content>
+						<div>
+							<CustomButton color="red" inverted @click="onDelete">
+								Delete Permission
+							</CustomButton>
+						</div>
 					</template>
 				</PanelSection>
 			</form>

--- a/apps/user-tools/src/pdc-api.ts
+++ b/apps/user-tools/src/pdc-api.ts
@@ -65,6 +65,41 @@ export const useCreatePermissionGrantCallback = () => {
 		});
 };
 
+export async function usePermissionGrant(id: number): Promise<PermissionGrant> {
+	const fetchOne = usePdcCallbackApi<PermissionGrant>(
+		`/permissionGrants/${id.toString()}`,
+	);
+	return await fetchOne({ method: 'GET' });
+}
+
+export const useUpdatePermissionGrantCallback = (id: number) => {
+	const api = usePdcCallbackApi<PermissionGrant>(
+		`/permissionGrants/${id.toString()}`,
+	);
+	return async (params: WritablePermissionGrantPayload) =>
+		await api({
+			method: 'PUT',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(params),
+		});
+};
+
+export const useDeletePermissionGrantCallback =
+	(id: number) => async (): Promise<void> => {
+		const { token } = useKeycloak();
+		const url = new URL(
+			`/permissionGrants/${id.toString()}`,
+			import.meta.env.VITE_API_URL,
+		);
+		await fetch(url.toString(), {
+			method: 'DELETE',
+			headers: { Authorization: `Bearer ${token}` },
+		}).then(throwIfNotOk);
+	};
+
 export function useSystemSource(): ReturnType<typeof usePdcApi<Source>> {
 	return usePdcApi<Source>('/sources/1');
 }

--- a/apps/user-tools/src/permissionsHelpers.ts
+++ b/apps/user-tools/src/permissionsHelpers.ts
@@ -157,6 +157,26 @@ export const getScopesForContextEntityType = (
 ): readonly string[] =>
 	isContextEntityType(value) ? CONTEXT_ENTITY_SCOPES[value] : [];
 
+export const rowToFormState = (
+	row: PermissionGrantRow,
+): PermissionGrantFormState => {
+	const entityKey = isContextEntityType(row.contextEntityType)
+		? row[CONTEXT_ENTITY_KEYS[row.contextEntityType]]
+		: undefined;
+	return {
+		granteeType: row.granteeType ?? null,
+		granteeId:
+			row.granteeUserKeycloakUserId ?? row.granteeKeycloakOrganizationId ?? '',
+		contextEntityType: row.contextEntityType,
+		entityKey:
+			typeof entityKey === 'string' || typeof entityKey === 'number'
+				? String(entityKey)
+				: '',
+		verbs: row.verbs,
+		scope: row.scope,
+	};
+};
+
 const MIN_ENTITY_ID = 1;
 
 /**

--- a/apps/user-tools/src/views/permissions/AddPermissionView.vue
+++ b/apps/user-tools/src/views/permissions/AddPermissionView.vue
@@ -16,5 +16,5 @@ const handleCreate = async (
 </script>
 
 <template>
-	<PermissionGrantForm :on-submit="handleCreate" />
+	<PermissionGrantForm mode="create" :on-submit="handleCreate" />
 </template>

--- a/apps/user-tools/src/views/permissions/EditPermissionView.vue
+++ b/apps/user-tools/src/views/permissions/EditPermissionView.vue
@@ -1,28 +1,77 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { getLogger } from '@pdc/utilities';
+import PermissionGrantForm from '../../components/permissions/PermissionGrantForm.vue';
 import {
-	PanelComponent,
-	PanelBody,
-	PanelHeader,
-	PanelHeaderActionsWrapper,
-	BackButton,
-} from '@pdc/components';
-import { useRoute } from 'vue-router';
+	usePermissionGrant,
+	useUpdatePermissionGrantCallback,
+	useDeletePermissionGrantCallback,
+} from '../../pdc-api';
+import {
+	rowToFormState,
+	type PermissionGrantFormState,
+	type PermissionGrantRow,
+	type WritablePermissionGrantPayload,
+} from '../../permissionsHelpers';
+
+const logger = getLogger('<EditPermissionView>');
+const route = useRoute();
+const router = useRouter();
 
 const {
-	params: { id: permissionId },
-} = useRoute();
+	params: { id: rawId },
+} = route;
+const permissionGrantId = Number(rawId);
+
+const initialValue = ref<PermissionGrantFormState | null>(null);
+const loadError = ref(false);
+
+const updateGrant = useUpdatePermissionGrantCallback(permissionGrantId);
+const deleteGrant = useDeletePermissionGrantCallback(permissionGrantId);
+
+onMounted(async () => {
+	try {
+		const grant = await usePermissionGrant(permissionGrantId);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SDK types omit grantee fields the API returns; see permissionsHelpers.ts
+		initialValue.value = rowToFormState(grant as unknown as PermissionGrantRow);
+	} catch (error) {
+		logger.error({ error }, 'Failed to load permission grant');
+		loadError.value = true;
+	}
+});
+
+const handleUpdate = async (
+	payload: WritablePermissionGrantPayload,
+): Promise<void> => {
+	await updateGrant(payload);
+	await router.push('/permissions');
+};
+
+const handleDelete = async (): Promise<void> => {
+	// eslint-disable-next-line no-alert -- intentional confirm() for destructive action; upgrade to modal TBD
+	const confirmed = window.confirm(
+		`Delete permission grant #${permissionGrantId.toString()}? This cannot be undone.`,
+	);
+	if (!confirmed) return;
+	await deleteGrant();
+	await router.push('/permissions');
+};
 </script>
 
 <template>
-	<PanelComponent padded>
-		<PanelHeader>
-			<h1>Permission Grant {{ permissionId }}</h1>
-			<PanelHeaderActionsWrapper>
-				<BackButton to="/permissions" label="Back to permissions" />
-			</PanelHeaderActionsWrapper>
-		</PanelHeader>
-		<PanelBody variant="padded">
-			<p>Permission grant view/edit coming soon.</p>
-		</PanelBody>
-	</PanelComponent>
+	<div v-if="loadError">
+		<p>Error loading permission grant.</p>
+	</div>
+	<div v-else-if="initialValue === null">
+		<p>Loading permission grant...</p>
+	</div>
+	<PermissionGrantForm
+		v-else
+		mode="edit"
+		:title="`Permission #${permissionGrantId.toString()}`"
+		:initial-value="initialValue"
+		:on-submit="handleUpdate"
+		:on-delete="handleDelete"
+	/>
 </template>


### PR DESCRIPTION
This commit extends the PermissionGrantForm component to be used for the permission edit view. The main functional piece it introduces is the row to form state function, which is used for filling in the state of the permission at edit view load time.

Closes #1364