### PR TITLE
Add human readable labels for related permission entities

### DIFF
--- a/apps/admin-interface/package.json
+++ b/apps/admin-interface/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.7",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.36.1",
+		"@pdc/sdk": "^0.37.1",
 		"@vitejs/plugin-vue": "^6.0.7",
 		"@vue/compiler-sfc": "^3.5.34",
 		"dayjs": "^1.11.20",

--- a/apps/admin-interface/src/pdc-api.ts
+++ b/apps/admin-interface/src/pdc-api.ts
@@ -2,7 +2,7 @@ import { usePdcApi, usePdcCallbackApi } from '@pdc/utilities';
 import type { BaseField, BaseFieldBundle, WritableBaseField } from '@pdc/sdk';
 
 const DEFAULT_ENTITY_PAGE = 1;
-const DEFAULT_ENTITY_COUNT = 200;
+const DEFAULT_ENTITY_COUNT = 1000;
 
 export function useBaseFields(
 	page: number = DEFAULT_ENTITY_PAGE,

--- a/apps/user-tools/package.json
+++ b/apps/user-tools/package.json
@@ -6,7 +6,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.7",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.36.1",
+		"@pdc/sdk": "^0.37.1",
 		"@vitejs/plugin-vue": "^6.0.7",
 		"@vue/compiler-sfc": "^3.5.34",
 		"dayjs": "^1.11.20",

--- a/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
+++ b/apps/user-tools/src/components/permissions/PermissionGrantForm.vue
@@ -23,6 +23,7 @@ import {
 	buildPermissionGrantPayload,
 	getEntityKeyPlaceholder,
 	getScopesForContextEntityType,
+	humanLabel,
 	isFormReady,
 	type PermissionGrantFormState,
 	type WritablePermissionGrantPayload,
@@ -68,7 +69,7 @@ const errorMessage = ref('');
 
 const scopeOptions = computed(() =>
 	getScopesForContextEntityType(form.contextEntityType).map((s) => ({
-		label: s,
+		label: humanLabel(s),
 		value: s,
 	})),
 );
@@ -77,11 +78,26 @@ const entityKeyPlaceholder = computed(() =>
 	getEntityKeyPlaceholder(form.contextEntityType),
 );
 
+const contextEntityLabel = computed(() =>
+	typeof form.contextEntityType === 'string'
+		? humanLabel(form.contextEntityType).toLowerCase()
+		: '',
+);
+
 const granteeNoun = computed(() => {
 	if (form.granteeType === 'user') return 'the user';
 	if (form.granteeType === 'userGroup') return 'the group';
-	return 'the user or group';
+	if (form.granteeType === 'authenticatedUsers')
+		return 'all authenticated users';
+	return 'the user, group, or audience';
 });
+
+const granteeRequiresId = computed(
+	() =>
+		form.granteeType === 'user' ||
+		form.granteeType === 'userGroup' ||
+		form.granteeType === null,
+);
 
 watch(
 	() => form.contextEntityType,
@@ -137,7 +153,7 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 						>
 							<template #header>Grantee type</template>
 						</RadioInput>
-						<TextInput v-model="form.granteeId">
+						<TextInput v-if="granteeRequiresId" v-model="form.granteeId">
 							<template #header>Grantee ID</template>
 							<template #instructions>
 								The Keycloak UUID for {{ granteeNoun }} (e.g.,
@@ -189,7 +205,7 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 							<template #header>{{ entityKeyPlaceholder }}</template>
 							<template #instructions>
 								Enter the {{ entityKeyPlaceholder.toLowerCase() }} for the
-								{{ form.contextEntityType }}.
+								{{ contextEntityLabel }}.
 							</template>
 						</TextInput>
 						<CheckboxInput

--- a/apps/user-tools/src/pdc-api.ts
+++ b/apps/user-tools/src/pdc-api.ts
@@ -27,7 +27,7 @@ export type FileUploadResponse = ModelFile & {
 };
 
 const DEFAULT_ENTITY_PAGE = 1;
-const DEFAULT_ENTITY_COUNT = 1000;
+const { MAX_SAFE_INTEGER: DEFAULT_ENTITY_COUNT } = Number;
 
 export function useBulkUploads(
 	page: number = DEFAULT_ENTITY_PAGE,

--- a/apps/user-tools/src/pdc-api.ts
+++ b/apps/user-tools/src/pdc-api.ts
@@ -16,6 +16,9 @@ import type {
 	Opportunity,
 	PermissionGrant,
 	PermissionGrantBundle,
+	ChangemakerBundle,
+	DataProviderBundle,
+	ProposalBundle,
 } from '@pdc/sdk';
 import type { WritablePermissionGrantPayload } from './permissionsHelpers';
 
@@ -24,7 +27,7 @@ export type FileUploadResponse = ModelFile & {
 };
 
 const DEFAULT_ENTITY_PAGE = 1;
-const DEFAULT_ENTITY_COUNT = 200;
+const DEFAULT_ENTITY_COUNT = 1000;
 
 export function useBulkUploads(
 	page: number = DEFAULT_ENTITY_PAGE,
@@ -248,4 +251,43 @@ export function useOpportunities(
 export async function useOpportunity(id: number): Promise<Opportunity> {
 	const fetchOne = usePdcCallbackApi<Opportunity>(`/opportunities/${id}`);
 	return await fetchOne({ method: 'GET' });
+}
+
+export function useChangemakers(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<ChangemakerBundle>> {
+	return usePdcApi<ChangemakerBundle>(
+		'/changemakers',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useDataProviders(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<DataProviderBundle>> {
+	return usePdcApi<DataProviderBundle>(
+		'/dataProviders',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
+}
+
+export function useProposals(
+	page: number = DEFAULT_ENTITY_PAGE,
+	count: number = DEFAULT_ENTITY_COUNT,
+): ReturnType<typeof usePdcApi<ProposalBundle>> {
+	return usePdcApi<ProposalBundle>(
+		'/proposals',
+		new URLSearchParams({
+			_page: page.toString(),
+			_count: count.toString(),
+		}),
+	);
 }

--- a/apps/user-tools/src/permissionsHelpers.ts
+++ b/apps/user-tools/src/permissionsHelpers.ts
@@ -1,42 +1,24 @@
-/**
- * Local types and lookups for permission grants.
- *
- * Much of this file exists to paper over gaps in the generated `@pdc/sdk`
- * types — see PhilanthropyDataCommons/service#2353 for the full list of
- * SDK issues being tracked. When that lands, the reshaped types and
- * hardcoded enum/scope tables here should fall out.
- */
+import {
+	PermissionGrantEntityType,
+	PermissionGrantGranteeType,
+	PermissionGrantVerb,
+} from '@pdc/sdk';
 import type { PermissionGrant } from '@pdc/sdk';
 
-/**
- * API-shaped permission grant row. The SDK's `PermissionGrant` omits
- * grantee fields and types `scope`/`verbs` as opaque empty interfaces, so
- * we reshape here. Tracks service#2353.
- */
-export type PermissionGrantRow = Omit<PermissionGrant, 'scope' | 'verbs'> & {
+export type PermissionGrantRow = Omit<PermissionGrant, 'scope'> & {
 	scope: string[];
-	verbs: string[];
 	granteeType?: string;
 	granteeUserKeycloakUserId?: string | null;
 	granteeKeycloakOrganizationId?: string | null;
 };
 
-export const CONTEXT_ENTITY_TYPES = [
-	'changemaker',
-	'funder',
-	'dataProvider',
-	'opportunity',
-	'proposal',
-	'proposalVersion',
-	'applicationForm',
-	'applicationFormField',
-	'proposalFieldValue',
-	'source',
-	'bulkUpload',
-	'changemakerFieldValue',
-] as const;
+export type ContextEntityType = Exclude<`${PermissionGrantEntityType}`, 'any'>;
 
-export type ContextEntityType = (typeof CONTEXT_ENTITY_TYPES)[number];
+export const CONTEXT_ENTITY_TYPES: readonly ContextEntityType[] = (
+	Object.values(
+		PermissionGrantEntityType,
+	) as ReadonlyArray<`${PermissionGrantEntityType}`>
+).filter((value): value is ContextEntityType => value !== 'any');
 
 export const CONTEXT_ENTITY_KEYS: Record<
 	ContextEntityType,
@@ -61,66 +43,73 @@ export const CONTEXT_ENTITY_KEY_IS_SHORT_CODE: ReadonlySet<string> = new Set([
 	'dataProvider',
 ]);
 
-/**
- * Valid `scope` values per `contextEntityType`. Mirrors
- * `contextEntityTypeScopes` in service/src/types/PermissionGrant.ts; keep
- * in sync when the service adds or changes a context type.
- */
 export const CONTEXT_ENTITY_SCOPES: Record<
 	ContextEntityType,
-	readonly ContextEntityType[]
+	ReadonlyArray<`${PermissionGrantEntityType}`>
 > = {
 	changemaker: [
 		'changemaker',
 		'changemakerFieldValue',
 		'proposal',
 		'proposalFieldValue',
+		'any',
 	],
-	funder: ['funder', 'opportunity', 'proposal', 'proposalFieldValue'],
-	dataProvider: ['dataProvider'],
-	opportunity: ['opportunity', 'proposal', 'proposalFieldValue'],
-	proposal: ['proposal', 'proposalFieldValue'],
-	proposalVersion: ['proposalVersion'],
-	applicationForm: ['applicationForm'],
-	applicationFormField: ['applicationFormField'],
-	proposalFieldValue: ['proposalFieldValue'],
-	source: ['source'],
-	bulkUpload: ['bulkUpload'],
-	changemakerFieldValue: ['changemakerFieldValue'],
+	funder: [
+		'funder',
+		'opportunity',
+		'applicationForm',
+		'proposal',
+		'proposalFieldValue',
+		'any',
+	],
+	dataProvider: ['dataProvider', 'any'],
+	opportunity: [
+		'opportunity',
+		'applicationForm',
+		'proposal',
+		'proposalFieldValue',
+		'any',
+	],
+	proposal: ['proposal', 'proposalFieldValue', 'any'],
+	proposalVersion: ['proposalVersion', 'any'],
+	applicationForm: ['applicationForm', 'any'],
+	applicationFormField: ['applicationFormField', 'any'],
+	proposalFieldValue: ['proposalFieldValue', 'any'],
+	source: ['source', 'any'],
+	bulkUpload: ['bulkUpload', 'any'],
+	changemakerFieldValue: ['changemakerFieldValue', 'any'],
 };
-
-export const PERMISSION_VERBS = [
-	'view',
-	'create',
-	'edit',
-	'delete',
-	'manage',
-] as const;
-
-export type PermissionVerb = (typeof PERMISSION_VERBS)[number];
 
 interface LabeledOption {
 	label: string;
 	value: string;
 }
 
-export const PERMISSION_VERB_OPTIONS: LabeledOption[] = [
-	{ label: 'View', value: 'view' },
-	{ label: 'Create', value: 'create' },
-	{ label: 'Edit', value: 'edit' },
-	{ label: 'Delete', value: 'delete' },
-	{ label: 'Manage', value: 'manage' },
-];
+export const humanLabel = (value: string): string =>
+	value
+		.replace(/(?<=[a-z])(?=[A-Z])/gu, ' ')
+		.replace(/^./u, (first) => first.toUpperCase());
 
-export type GranteeType = 'user' | 'userGroup';
+export const PERMISSION_VERB_OPTIONS: LabeledOption[] = Object.values(
+	PermissionGrantVerb,
+).map((verb) => ({ label: humanLabel(verb), value: verb }));
+
+export type GranteeType = `${PermissionGrantGranteeType}`;
 
 export const GRANTEE_TYPE_OPTIONS: LabeledOption[] = [
-	{ label: 'User', value: 'user' },
-	{ label: 'Group', value: 'userGroup' },
+	{ label: 'User', value: PermissionGrantGranteeType.User },
+	{ label: 'Group', value: PermissionGrantGranteeType.UserGroup },
+	{
+		label: 'All authenticated users',
+		value: PermissionGrantGranteeType.AuthenticatedUsers,
+	},
 ];
 
 export const CONTEXT_ENTITY_TYPE_OPTIONS: LabeledOption[] =
-	CONTEXT_ENTITY_TYPES.map((type) => ({ label: type, value: type }));
+	CONTEXT_ENTITY_TYPES.map((type) => ({
+		label: humanLabel(type),
+		value: type,
+	}));
 
 export const getEntityKeyPlaceholder = (
 	contextEntityType: string | null | undefined,
@@ -150,7 +139,11 @@ export const isContextEntityType = (
 
 export const isGranteeType = (
 	value: string | null | undefined,
-): value is GranteeType => value === 'user' || value === 'userGroup';
+): value is GranteeType =>
+	value === 'user' || value === 'userGroup' || value === 'authenticatedUsers';
+
+export const granteeTypeRequiresId = (granteeType: GranteeType): boolean =>
+	granteeType !== 'authenticatedUsers';
 
 export const getScopesForContextEntityType = (
 	value: string | null | undefined,
@@ -202,8 +195,15 @@ export type WritablePermissionGrantPayload = {
 	scope: string[];
 	verbs: string[];
 } & (
-	| { granteeType: 'user'; granteeUserKeycloakUserId: string }
-	| { granteeType: 'userGroup'; granteeKeycloakOrganizationId: string }
+	| {
+			granteeType: `${PermissionGrantGranteeType.User}`;
+			granteeUserKeycloakUserId: string;
+	  }
+	| {
+			granteeType: `${PermissionGrantGranteeType.UserGroup}`;
+			granteeKeycloakOrganizationId: string;
+	  }
+	| { granteeType: `${PermissionGrantGranteeType.AuthenticatedUsers}` }
 );
 
 export const formatEntityLabel = (row: PermissionGrantRow): string => {
@@ -217,15 +217,85 @@ export const formatEntityLabel = (row: PermissionGrantRow): string => {
 	return row.contextEntityType;
 };
 
+export const ENTITY_LABEL_FIELDS: Partial<
+	Record<ContextEntityType, { keyField: string; labelField: string }>
+> = {
+	changemaker: { keyField: 'id', labelField: 'name' },
+	funder: { keyField: 'shortCode', labelField: 'name' },
+	dataProvider: { keyField: 'shortCode', labelField: 'name' },
+	opportunity: { keyField: 'id', labelField: 'title' },
+	proposal: { keyField: 'id', labelField: 'externalId' },
+	applicationForm: { keyField: 'id', labelField: 'name' },
+	source: { keyField: 'id', labelField: 'label' },
+};
+
+export type EntityLabelLookup = ReadonlyMap<string, string>;
+
+const entityLabelMapKey = (
+	contextEntityType: string,
+	entityKey: string | number,
+): string => `${contextEntityType}:${String(entityKey)}`;
+
+const readEntityField = (entry: unknown, field: string): unknown => {
+	if (typeof entry !== 'object' || entry === null) return undefined;
+	if (!(field in entry)) return undefined;
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Dynamic field name driven by ENTITY_LABEL_FIELDS; SDK entry types don't carry an index signature.
+	return (entry as Record<string, unknown>)[field];
+};
+
+export const buildEntityLabelLookup = (
+	entityLists: Partial<
+		Record<ContextEntityType, readonly unknown[] | undefined>
+	>,
+): EntityLabelLookup => {
+	const lookup = new Map<string, string>();
+	for (const type of CONTEXT_ENTITY_TYPES) {
+		const { [type]: config } = ENTITY_LABEL_FIELDS;
+		const { [type]: entries } = entityLists;
+		if (config === undefined || entries === undefined) continue;
+		for (const entry of entries) {
+			const keyValue = readEntityField(entry, config.keyField);
+			const labelValue = readEntityField(entry, config.labelField);
+			if (
+				(typeof keyValue !== 'string' && typeof keyValue !== 'number') ||
+				typeof labelValue !== 'string' ||
+				labelValue === ''
+			)
+				continue;
+			lookup.set(entityLabelMapKey(type, keyValue), labelValue);
+		}
+	}
+	return lookup;
+};
+
+export const resolveEntityLabel = (
+	row: PermissionGrantRow,
+	lookup: EntityLabelLookup,
+): string => {
+	if (isContextEntityType(row.contextEntityType)) {
+		const { [row.contextEntityType]: key } = CONTEXT_ENTITY_KEYS;
+		const { [key]: value } = row;
+		if (typeof value === 'string' || typeof value === 'number') {
+			const label = lookup.get(entityLabelMapKey(row.contextEntityType, value));
+			if (label !== undefined) return label;
+		}
+	}
+	return formatEntityLabel(row);
+};
+
 const MIN_SELECTIONS = 1;
 
-export const isFormReady = (form: PermissionGrantFormState): boolean =>
-	isGranteeType(form.granteeType) &&
-	form.granteeId.trim() !== '' &&
-	isContextEntityType(form.contextEntityType) &&
-	isValidEntityKey(form.contextEntityType, form.entityKey) &&
-	form.verbs.length >= MIN_SELECTIONS &&
-	form.scope.length >= MIN_SELECTIONS;
+export const isFormReady = (form: PermissionGrantFormState): boolean => {
+	if (!isGranteeType(form.granteeType)) return false;
+	if (granteeTypeRequiresId(form.granteeType) && form.granteeId.trim() === '')
+		return false;
+	return (
+		isContextEntityType(form.contextEntityType) &&
+		isValidEntityKey(form.contextEntityType, form.entityKey) &&
+		form.verbs.length >= MIN_SELECTIONS &&
+		form.scope.length >= MIN_SELECTIONS
+	);
+};
 
 export const buildPermissionGrantPayload = (
 	form: PermissionGrantFormState,
@@ -248,10 +318,12 @@ export const buildPermissionGrantPayload = (
 		: Number(form.entityKey);
 
 	const granteeId = form.granteeId.trim();
-	const grantee =
+	const grantee: Record<string, string> =
 		granteeType === 'user'
 			? { granteeType, granteeUserKeycloakUserId: granteeId }
-			: { granteeType, granteeKeycloakOrganizationId: granteeId };
+			: granteeType === 'userGroup'
+				? { granteeType, granteeKeycloakOrganizationId: granteeId }
+				: { granteeType };
 
 	const payload: Record<string, unknown> = {
 		...grantee,

--- a/apps/user-tools/src/views/permissions/EditPermissionView.vue
+++ b/apps/user-tools/src/views/permissions/EditPermissionView.vue
@@ -11,7 +11,6 @@ import {
 import {
 	rowToFormState,
 	type PermissionGrantFormState,
-	type PermissionGrantRow,
 	type WritablePermissionGrantPayload,
 } from '../../permissionsHelpers';
 
@@ -33,8 +32,7 @@ const deleteGrant = useDeletePermissionGrantCallback(permissionGrantId);
 onMounted(async () => {
 	try {
 		const grant = await usePermissionGrant(permissionGrantId);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SDK types omit grantee fields the API returns; see permissionsHelpers.ts
-		initialValue.value = rowToFormState(grant as unknown as PermissionGrantRow);
+		initialValue.value = rowToFormState(grant);
 	} catch (error) {
 		logger.error({ error }, 'Failed to load permission grant');
 		loadError.value = true;

--- a/apps/user-tools/src/views/permissions/PermissionsView.vue
+++ b/apps/user-tools/src/views/permissions/PermissionsView.vue
@@ -12,10 +12,21 @@ import {
 import { RouterLink } from 'vue-router';
 import { PlusIcon } from '@heroicons/vue/24/outline';
 import { onMounted, ref, computed, h } from 'vue';
-import { usePermissionGrants } from '../../pdc-api';
+import {
+	usePermissionGrants,
+	useChangemakers,
+	useFunders,
+	useDataProviders,
+	useOpportunities,
+	useProposals,
+	useApplicationForms,
+	useSources,
+} from '../../pdc-api';
 import { getLogger } from '@pdc/utilities';
 import {
-	formatEntityLabel,
+	buildEntityLabelLookup,
+	humanLabel,
+	resolveEntityLabel,
 	type PermissionGrantRow,
 } from '../../permissionsHelpers';
 
@@ -23,13 +34,30 @@ const logger = getLogger('<PermissionsView>');
 
 const { data: permissionGrants, fetchData: fetchPermissionGrants } =
 	usePermissionGrants();
+const { data: changemakers } = useChangemakers();
+const { data: funders } = useFunders();
+const { data: dataProviders } = useDataProviders();
+const { data: opportunities } = useOpportunities();
+const { data: proposals } = useProposals();
+const { data: applicationForms } = useApplicationForms();
+const { data: sources } = useSources();
 const isLoading = ref(true);
 const caughtError = ref(false);
 
 const permissionGrantsArray = computed<PermissionGrantRow[]>(
-	() =>
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SDK types omit grantee fields and type scope/verbs as opaque; see permissionsHelpers.ts
-		(permissionGrants.value?.entries ?? []) as unknown as PermissionGrantRow[],
+	() => permissionGrants.value?.entries ?? [],
+);
+
+const entityLabelLookup = computed(() =>
+	buildEntityLabelLookup({
+		changemaker: changemakers.value?.entries,
+		funder: funders.value?.entries,
+		dataProvider: dataProviders.value?.entries,
+		opportunity: opportunities.value?.entries,
+		proposal: proposals.value?.entries,
+		applicationForm: applicationForms.value?.entries,
+		source: sources.value?.entries,
+	}),
 );
 
 const columnHelper = createColumnHelper<PermissionGrantRow>();
@@ -37,18 +65,28 @@ const columnHelper = createColumnHelper<PermissionGrantRow>();
 const columns = [
 	columnHelper.text('id', 'Id'),
 	columnHelper.display('granteeType', 'Grantee Type', {
-		cell: (info) => info.row.original.granteeType ?? '',
+		cell: (info) => {
+			const {
+				row: {
+					original: { granteeType },
+				},
+			} = info;
+			return typeof granteeType === 'string' ? humanLabel(granteeType) : '';
+		},
 	}),
-	columnHelper.text('contextEntityType', 'Context Entity'),
+	columnHelper.display('contextEntityType', 'Context Entity', {
+		cell: (info) => humanLabel(info.row.original.contextEntityType),
+	}),
 	columnHelper.display('entityLabel', 'Entity Label', {
-		cell: (info) => formatEntityLabel(info.row.original),
+		cell: (info) =>
+			resolveEntityLabel(info.row.original, entityLabelLookup.value),
 		enableSorting: false,
 	}),
 	columnHelper.accessor('scope', 'Scope', {
-		cell: (info) => info.getValue().join(', '),
+		cell: (info) => info.getValue().map(humanLabel).join(', '),
 	}),
 	columnHelper.accessor('verbs', 'Verbs', {
-		cell: (info) => info.getValue().join(', '),
+		cell: (info) => info.getValue().map(humanLabel).join(', '),
 	}),
 	columnHelper.text('createdByUser.keycloakUserName', 'Created By'),
 	columnHelper.icon('edit', '', (row) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.7",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.36.1",
+				"@pdc/sdk": "^0.37.1",
 				"@vitejs/plugin-vue": "^6.0.7",
 				"@vue/compiler-sfc": "^3.5.34",
 				"dayjs": "^1.11.20",
@@ -64,6 +64,12 @@
 				"node": ">=22"
 			}
 		},
+		"apps/admin-interface/node_modules/@pdc/sdk": {
+			"version": "0.37.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.37.1.tgz",
+			"integrity": "sha512-cKGBiInggrCnn9BGEYgM1Ey2+ju+ipzTvWa+bgoW/9G2xIXIVuD8Tdyny9zi/fA3R5w33TVsMkOhlfuX+x8dfA==",
+			"license": "AGPL-3.0"
+		},
 		"apps/user-tools": {
 			"name": "@pdc/user-tools",
 			"version": "0.0.0",
@@ -71,7 +77,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.7",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.36.1",
+				"@pdc/sdk": "^0.37.1",
 				"@vitejs/plugin-vue": "^6.0.7",
 				"@vue/compiler-sfc": "^3.5.34",
 				"dayjs": "^1.11.20",
@@ -85,6 +91,12 @@
 			"engines": {
 				"node": ">=22"
 			}
+		},
+		"apps/user-tools/node_modules/@pdc/sdk": {
+			"version": "0.37.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.37.1.tgz",
+			"integrity": "sha512-cKGBiInggrCnn9BGEYgM1Ey2+ju+ipzTvWa+bgoW/9G2xIXIVuD8Tdyny9zi/fA3R5w33TVsMkOhlfuX+x8dfA==",
+			"license": "AGPL-3.0"
 		},
 		"node_modules/@acemir/cssom": {
 			"version": "0.9.31",
@@ -144,7 +156,6 @@
 			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.27.1",
 				"js-tokens": "^4.0.0",
@@ -255,7 +266,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
 			"integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -377,6 +387,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -417,6 +428,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1276,12 +1288,6 @@
 			"resolved": "packages/components",
 			"link": true
 		},
-		"node_modules/@pdc/sdk": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.36.1.tgz",
-			"integrity": "sha512-UpLLOklYguJ00dFSU27ifOiWInemMJsqOar3SvNlXmlIFAmn9w+6cXXA6suWmSdSLvgl2ZjyITMG+YumV1Ivcw==",
-			"license": "AGPL-3.0"
-		},
 		"node_modules/@pdc/user-tools": {
 			"resolved": "apps/user-tools",
 			"link": true
@@ -1851,7 +1857,6 @@
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
 			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -1871,7 +1876,6 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -1929,8 +1933,7 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.2",
@@ -1993,6 +1996,7 @@
 			"integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -2001,8 +2005,7 @@
 			"version": "15.7.12",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
 			"integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/qs": {
 			"version": "6.15.0",
@@ -2067,6 +2070,7 @@
 			"integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.4",
 				"@typescript-eslint/types": "8.59.4",
@@ -2769,6 +2773,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2823,7 +2828,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3582,8 +3586,7 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
@@ -3783,6 +3786,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -3849,6 +3853,7 @@
 			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5462,6 +5467,7 @@
 			"integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@acemir/cssom": "^0.9.31",
 				"@asamuzakjp/dom-selector": "^6.8.1",
@@ -5502,6 +5508,7 @@
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -5700,7 +5707,6 @@
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -6287,6 +6293,7 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6302,7 +6309,6 @@
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -6317,7 +6323,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -6537,6 +6542,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -6549,6 +6555,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -6561,8 +6568,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/readdirp": {
 			"version": "5.0.0",
@@ -6643,8 +6649,7 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
@@ -7069,6 +7074,7 @@
 			"integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@storybook/global": "^5.0.0",
 				"@testing-library/jest-dom": "^6.6.3",
@@ -7546,6 +7552,7 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7672,6 +7679,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -8415,6 +8423,7 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
 			"integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.34",
 				"@vue/compiler-sfc": "3.5.34",
@@ -8499,6 +8508,7 @@
 			"integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"eslint-scope": "^8.2.0 || ^9.0.0",
@@ -8978,7 +8988,7 @@
 				"@dsb-norge/vue-keycloak-js": "^3.0.7",
 				"@fontsource/source-sans-pro": "^5.2.5",
 				"@heroicons/vue": "^2.2.0",
-				"@pdc/sdk": "^0.36.1",
+				"@pdc/sdk": "^0.37.1",
 				"@tanstack/vue-table": "^8.21.3",
 				"@vitejs/plugin-vue": "^6.0.7",
 				"@vue/compiler-sfc": "^3.5.34",
@@ -8990,6 +9000,12 @@
 				"vue-router": "^5.0.7",
 				"web-vitals": "^5.2.0"
 			}
+		},
+		"packages/components/node_modules/@pdc/sdk": {
+			"version": "0.37.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.37.1.tgz",
+			"integrity": "sha512-cKGBiInggrCnn9BGEYgM1Ey2+ju+ipzTvWa+bgoW/9G2xIXIVuD8Tdyny9zi/fA3R5w33TVsMkOhlfuX+x8dfA==",
+			"license": "AGPL-3.0"
 		},
 		"packages/shared": {
 			"name": "@pdc/shared",
@@ -9036,7 +9052,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@dsb-norge/vue-keycloak-js": "^3.0.7",
-				"@pdc/sdk": "^0.36.1",
+				"@pdc/sdk": "^0.37.1",
 				"@vitejs/plugin-vue": "^6.0.7",
 				"@vue/compiler-sfc": "^3.5.34",
 				"dayjs": "^1.11.20",
@@ -9049,6 +9065,12 @@
 				"vue-router": "^5.0.7",
 				"web-vitals": "^5.2.0"
 			}
+		},
+		"packages/utilities/node_modules/@pdc/sdk": {
+			"version": "0.37.1",
+			"resolved": "https://registry.npmjs.org/@pdc/sdk/-/sdk-0.37.1.tgz",
+			"integrity": "sha512-cKGBiInggrCnn9BGEYgM1Ey2+ju+ipzTvWa+bgoW/9G2xIXIVuD8Tdyny9zi/fA3R5w33TVsMkOhlfuX+x8dfA==",
+			"license": "AGPL-3.0"
 		}
 	}
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
 		"@dsb-norge/vue-keycloak-js": "^3.0.7",
 		"@fontsource/source-sans-pro": "^5.2.5",
 		"@heroicons/vue": "^2.2.0",
-		"@pdc/sdk": "^0.36.1",
+		"@pdc/sdk": "^0.37.1",
 		"@tanstack/vue-table": "^8.21.3",
 		"@vitejs/plugin-vue": "^6.0.7",
 		"@vue/compiler-sfc": "^3.5.34",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@dsb-norge/vue-keycloak-js": "^3.0.7",
-		"@pdc/sdk": "^0.36.1",
+		"@pdc/sdk": "^0.37.1",
 		"@vitejs/plugin-vue": "^6.0.7",
 		"@vue/compiler-sfc": "^3.5.34",
 		"dayjs": "^1.11.20",


### PR DESCRIPTION
This commit adds a front-end-only constructor for resolving human readable labels on related permissions entities. It does a pre-fetch of all related entities and then uses the resolver functions to get out the human readable label and render it. A lot of this code should be able to be cut down when we can get oneOf/anyOf types working in our sdk.

Closes #1379 