### PR TITLE
Gate loading of related entity labels

### DIFF
--- a/apps/user-tools/src/permissionsHelpers.ts
+++ b/apps/user-tools/src/permissionsHelpers.ts
@@ -224,7 +224,6 @@ export const ENTITY_LABEL_FIELDS: Partial<
 	funder: { keyField: 'shortCode', labelField: 'name' },
 	dataProvider: { keyField: 'shortCode', labelField: 'name' },
 	opportunity: { keyField: 'id', labelField: 'title' },
-	proposal: { keyField: 'id', labelField: 'externalId' },
 	applicationForm: { keyField: 'id', labelField: 'name' },
 	source: { keyField: 'id', labelField: 'label' },
 };
@@ -282,6 +281,14 @@ export const resolveEntityLabel = (
 	}
 	return formatEntityLabel(row);
 };
+
+export const isEntityLabelPending = (
+	row: PermissionGrantRow,
+	loadingEntityTypes: ReadonlySet<ContextEntityType>,
+): boolean =>
+	isContextEntityType(row.contextEntityType) &&
+	row.contextEntityType in ENTITY_LABEL_FIELDS &&
+	loadingEntityTypes.has(row.contextEntityType);
 
 const MIN_SELECTIONS = 1;
 

--- a/apps/user-tools/src/views/permissions/PermissionsView.vue
+++ b/apps/user-tools/src/views/permissions/PermissionsView.vue
@@ -18,7 +18,6 @@ import {
 	useFunders,
 	useDataProviders,
 	useOpportunities,
-	useProposals,
 	useApplicationForms,
 	useSources,
 } from '../../pdc-api';
@@ -26,7 +25,9 @@ import { getLogger } from '@pdc/utilities';
 import {
 	buildEntityLabelLookup,
 	humanLabel,
+	isEntityLabelPending,
 	resolveEntityLabel,
+	type ContextEntityType,
 	type PermissionGrantRow,
 } from '../../permissionsHelpers';
 
@@ -34,13 +35,16 @@ const logger = getLogger('<PermissionsView>');
 
 const { data: permissionGrants, fetchData: fetchPermissionGrants } =
 	usePermissionGrants();
-const { data: changemakers } = useChangemakers();
-const { data: funders } = useFunders();
-const { data: dataProviders } = useDataProviders();
-const { data: opportunities } = useOpportunities();
-const { data: proposals } = useProposals();
-const { data: applicationForms } = useApplicationForms();
-const { data: sources } = useSources();
+const { data: changemakers, isLoading: changemakersLoading } =
+	useChangemakers();
+const { data: funders, isLoading: fundersLoading } = useFunders();
+const { data: dataProviders, isLoading: dataProvidersLoading } =
+	useDataProviders();
+const { data: opportunities, isLoading: opportunitiesLoading } =
+	useOpportunities();
+const { data: applicationForms, isLoading: applicationFormsLoading } =
+	useApplicationForms();
+const { data: sources, isLoading: sourcesLoading } = useSources();
 const isLoading = ref(true);
 const caughtError = ref(false);
 
@@ -54,10 +58,27 @@ const entityLabelLookup = computed(() =>
 		funder: funders.value?.entries,
 		dataProvider: dataProviders.value?.entries,
 		opportunity: opportunities.value?.entries,
-		proposal: proposals.value?.entries,
 		applicationForm: applicationForms.value?.entries,
 		source: sources.value?.entries,
 	}),
+);
+
+const labelEntityLoading = [
+	['changemaker', changemakersLoading],
+	['funder', fundersLoading],
+	['dataProvider', dataProvidersLoading],
+	['opportunity', opportunitiesLoading],
+	['applicationForm', applicationFormsLoading],
+	['source', sourcesLoading],
+] as const satisfies ReadonlyArray<readonly [ContextEntityType, unknown]>;
+
+const loadingEntityTypes = computed(
+	() =>
+		new Set(
+			labelEntityLoading
+				.filter(([, loading]) => loading.value)
+				.map(([type]) => type),
+		),
 );
 
 const columnHelper = createColumnHelper<PermissionGrantRow>();
@@ -78,8 +99,19 @@ const columns = [
 		cell: (info) => humanLabel(info.row.original.contextEntityType),
 	}),
 	columnHelper.display('entityLabel', 'Entity Label', {
-		cell: (info) =>
-			resolveEntityLabel(info.row.original, entityLabelLookup.value),
+		cell: (info) => {
+			const {
+				row: { original: row },
+			} = info;
+			if (isEntityLabelPending(row, loadingEntityTypes.value)) {
+				return h(
+					'span',
+					{ class: 'text-gray-500', 'aria-busy': 'true' },
+					'Loading…',
+				);
+			}
+			return resolveEntityLabel(row, entityLabelLookup.value);
+		},
 		enableSorting: false,
 	}),
 	columnHelper.accessor('scope', 'Scope', {

--- a/packages/utilities/src/api-hooks.ts
+++ b/packages/utilities/src/api-hooks.ts
@@ -22,11 +22,21 @@ export function throwIfNotOk(res: Response): Response {
 export function usePdcApi<T>(
 	path: string,
 	params = new URLSearchParams(),
-): { data: Ref<T | null>; fetchData: () => Promise<void> } {
+): {
+	data: Ref<T | null>;
+	fetchData: () => Promise<void>;
+	isLoading: Ref<boolean>;
+	error: Ref<unknown>;
+} {
 	const data: Ref<T | null> = ref(null);
+
+	const isLoading = ref(true);
+	const error: Ref<unknown> = ref(null);
 
 	const fetchData = async (): Promise<void> => {
 		data.value = null;
+		error.value = null;
+		isLoading.value = true;
 		try {
 			const { token } = useKeycloak();
 			const url = new URL(path, API_URL);
@@ -40,10 +50,13 @@ export function usePdcApi<T>(
 			 */
 			data.value = (await res.json()) as T;
 		} catch (err) {
+			error.value = err;
 			logger.error(
 				{ error: err, params: params.toString() },
 				`Error fetching ${path}`,
 			);
+		} finally {
+			isLoading.value = false;
 		}
 	};
 
@@ -51,7 +64,7 @@ export function usePdcApi<T>(
 
 	watch(() => params.toString(), fetchData);
 
-	return { data, fetchData };
+	return { data, fetchData, isLoading, error };
 }
 
 export function usePdcCallbackApi<T>(


### PR DESCRIPTION
This PR defaults related entities to 'loading' when they are still being resolved as part of the pre-fetch, and nixes resolving proposals to their externalID (which are not human readable labels in any practical sense).

Closes #1401 