### PR TITLE
Add infoblock for explicitly indicating changemaker in bulk upload

### DIFF
--- a/apps/user-tools/src/components/bulk-upload/BulkUploader.vue
+++ b/apps/user-tools/src/components/bulk-upload/BulkUploader.vue
@@ -221,6 +221,13 @@ const handleFormSubmit = async (event: Event): Promise<void> => {
 									Every row must include a valid email address in the
 									<CodeText>proposal_submitter_email</CodeText> column.
 								</InfoBlock>
+								<InfoBlock>
+									Set a row's <CodeText>pdc_changemaker_id</CodeText> to a
+									changemaker's PDC ID to link it to that exact changemaker —
+									this takes precedence over matching by
+									<CodeText>organization_name</CodeText> and
+									<CodeText>organization_tax_id</CodeText>.
+								</InfoBlock>
 							</template>
 						</FileUploadInput>
 					</template>


### PR DESCRIPTION
Related to service [issue #2466](https://github.com/PhilanthropyDataCommons/service/issues/2466)

This PR simply encompasses explicitly documenting the behavior of the `pdc_changemaker_id` column as an explicit single identifier of a related changemaker in the bulkupload.

Closes #1389 